### PR TITLE
Add simple shadow property support

### DIFF
--- a/EFCore.BulkExtensions/ObjectReaderEx.cs
+++ b/EFCore.BulkExtensions/ObjectReaderEx.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using FastMember;
+using Microsoft.EntityFrameworkCore;
+
+namespace EFCore.BulkExtensions
+{
+    internal class ObjectReaderEx : ObjectReader
+    {
+        private readonly HashSet<string> _shadowProperties;
+        private readonly DbContext _context;
+        private string[] _members;
+        private static TypeAccessor _accessor = TypeAccessor.Create(typeof(ObjectReader), true);
+        private FieldInfo _current;
+
+        internal static object GetInstanceField(Type type, object instance, string fieldName)
+        {
+            FieldInfo field = type.GetField("current", BindingFlags.Instance | BindingFlags.NonPublic);
+            return field.GetValue(instance);
+        }
+
+        public ObjectReaderEx(Type type, IEnumerable source, HashSet<string> shadowProperties, DbContext context, params string[] members) : base(type, source, members)
+        {
+            _shadowProperties = shadowProperties;
+            _context = context;
+            _members = members;
+            _current = typeof(ObjectReader).GetField("current", BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        public static ObjectReaderEx Create<T>(IEnumerable<T> source, HashSet<string> shadowProperties, DbContext context, params string[] members)
+        {
+            return new ObjectReaderEx(typeof(T), source, shadowProperties, context, members);
+        }
+
+        public override object this[string name]
+        {
+            get
+            {
+                if (_shadowProperties.Contains(name))
+                {
+                    var current = _current.GetValue(this);
+                    return _context.Entry(current).Property(name).CurrentValue;
+                }
+
+                return base[name];
+            }
+        }
+
+        public override object this[int i]
+        {
+            get
+            {
+                var name = _members[i];
+
+                return this[name];
+            }
+        }
+    }
+}

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
-using FastMember;
 using Microsoft.EntityFrameworkCore;
 
 namespace EFCore.BulkExtensions
@@ -27,7 +26,7 @@ namespace EFCore.BulkExtensions
                 using (var sqlBulkCopy = new SqlBulkCopy(sqlConnection))
                 {
                     tableInfo.SetSqlBulkCopyConfig(sqlBulkCopy, entities, progress);
-                    using (var reader = ObjectReader.Create(entities, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
+                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
                     {
                         sqlBulkCopy.WriteToServer(reader);
                     }
@@ -48,7 +47,7 @@ namespace EFCore.BulkExtensions
                 using (var sqlBulkCopy = new SqlBulkCopy(sqlConnection))
                 {
                     tableInfo.SetSqlBulkCopyConfig(sqlBulkCopy, entities, progress);
-                    using (var reader = ObjectReader.Create(entities, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
+                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
                     {
                         await sqlBulkCopy.WriteToServerAsync(reader).ConfigureAwait(false);
                     }


### PR DESCRIPTION
This is my take on issue #15 - it's not perfect as it potentially can decrease performance for types without shadow properties (probably can add "if" to ObjectReaderEx.Create and return ObjectReader if no shadow properties present).
Also, it uses reflection to get current item out of ObjectReader. The only other option I see is copying entire ObjectReader implementation onto our project to make "current" field protected instead of private which isn't great either.