### PR TITLE
Update SqlQueryBuilder.cs

### DIFF
--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -59,7 +59,7 @@ namespace EFCore.BulkExtensions
 
             if (tableInfo.BulkConfig.SetOutputIdentity)
             {
-                q += $" OUTPUT INSERTED.* INTO dbo.{tableInfo.FullTempOutputTableName}";
+                q += $" OUTPUT INSERTED.* INTO {(tableInfo.Schema == null ? "dbo.":"")}{tableInfo.FullTempOutputTableName}";
             }
 
             return q + ";";


### PR DESCRIPTION
If the table was in a different schema (than dbo) it added an unnecessary "dbo." prefix, which was causing an error when the SetOutputIdentity was true.