### PR TITLE
Fix bulk inserting with option SetOutputIdentity

### DIFF
--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -12,9 +12,9 @@ namespace EFCore.BulkExtensions
             return q;
         }
 
-        public static string SelectFromTable(string tableName, string orderByColumnName)
+        public static string SelectFromTable(string tableName)
         {
-            return $"SELECT * FROM {tableName} ORDER BY {orderByColumnName};";
+            return $"SELECT * FROM {tableName};";
         }
 
         public static string DropTable(string tableName)


### PR DESCRIPTION
**Steps to reproduce:**

1. Implement DB context with [global query filters](https://docs.microsoft.com/en-us/ef/core/querying/filters).

2. Execute bulk insert method with option SetOutputIdentity=true.

`Context.BulkInsert(entities, new BulkConfig { PreserveInsertOrder = true, BatchSize = 500, SetOutputIdentity = true});`

**Actual result:**
Method throws an exception.

**Expected result:**
No exception should be thrown.