### PR TITLE
Fixes issue with BulkInsert when SetOutputIdentity = true and primary key column name is different than the property name

### DIFF
--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -31,7 +31,7 @@ namespace EFCore.BulkExtensions
         {
             string targetTable = tableInfo.FullTableName;
             string sourceTable = tableInfo.FullTempTableName;
-            List<string> primaryKeys = tableInfo.PrimaryKeys;
+            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
             List<string> columnsNames = tableInfo.PropertyColumnNamesDict.Values.ToList();
             List<string> nonIdentityColumnsNames = columnsNames.Where(a => !primaryKeys.Contains(a)).ToList();
             List<string> insertColumnsNames = tableInfo.HasIdentity ? nonIdentityColumnsNames : columnsNames;

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -90,7 +90,7 @@ namespace EFCore.BulkExtensions
                     {
                         if (currentTransaction != null)
                             command.Transaction = currentTransaction.GetDbTransaction();
-                        command.CommandText = SqlQueryBuilder.SelectIsIdentity(FullTableName, PrimaryKeys[0]);
+                        command.CommandText = SqlQueryBuilder.SelectIsIdentity(FullTableName, PropertyColumnNamesDict[PrimaryKeys[0]]);
                         using (var reader = command.ExecuteReader())
                         {
                             if (reader.HasRows)
@@ -130,7 +130,7 @@ namespace EFCore.BulkExtensions
                     {
                         if (currentTransaction != null)
                             command.Transaction = currentTransaction.GetDbTransaction();
-                        command.CommandText = SqlQueryBuilder.SelectIsIdentity(FullTableName, PrimaryKeys[0]);
+                        command.CommandText = SqlQueryBuilder.SelectIsIdentity(FullTableName, PropertyColumnNamesDict[PrimaryKeys[0]]);
                         using (var reader = await command.ExecuteReaderAsync().ConfigureAwait(false))
                         {
                             if (reader.HasRows)


### PR DESCRIPTION
Fixes issue #33 

Was running a SQL Script checking for identity column and was using wrong column name throwing a SqlException. Uses the existing column mapping to map the primary key property to the actual column name