### PR TITLE
Added support for ValueConverters introduced in EFCore v2.1.0

### DIFF
--- a/EFCore.BulkExtensions.Tests/DbDataReaderExtensions.cs
+++ b/EFCore.BulkExtensions.Tests/DbDataReaderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EFCore.BulkExtensions.Tests
+{
+    public static class DbDataReaderExtensions
+    {
+        public static T Field<T>(this DbDataReader reader, string columnName)
+        {
+            var columnIndex = reader.GetOrdinal(columnName);
+            return reader.GetFieldValue<T>(columnIndex);
+        }
+
+        public static async Task<T> FieldAsync<T>(this DbDataReader reader, string columnName)
+        {
+            var columnIndex = reader.GetOrdinal(columnName);
+            return await reader.GetFieldValueAsync<T>(columnIndex);
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="RT.Comb" Version="2.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -44,7 +44,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info " + Guid.NewGuid().ToString().Substring(0, 3),
                         Quantity = i % 10,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = DateTime.Now
+                        TimeUpdated = DateTime.Now,
+                        ConvertedTime = DateTime.Now
                     });
                 }
                 if (insertTo2Tables)
@@ -123,7 +124,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info",
                         Quantity = i + 100,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = dateTimeNow
+                        TimeUpdated = dateTimeNow,
+                        ConvertedTime = dateTimeNow
                     });
                 }
                 if (isBulkOperation)

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
@@ -9,8 +10,8 @@ namespace EFCore.BulkExtensions.Tests
 {
     public class EFCoreBulkTest
     {
-        private int entitiesNumber = 100000;
-        
+        private int entitiesNumber = 10000;
+
         [Theory]
         //[InlineData(true)]
         [InlineData(true, true)]
@@ -18,9 +19,15 @@ namespace EFCore.BulkExtensions.Tests
         public void OperationsTest(bool isBulkOperation, bool insertTo2Tables = false)
         {
             // Test can be run individually by commenting others and running each separately in order one after another
-            RunInsert(isBulkOperation, insertTo2Tables);
-            RunInsertOrUpdate(isBulkOperation);
-            RunUpdate(isBulkOperation);
+            var dateTime = new DateTime(2018, 1, 1);
+            RunInsert(isBulkOperation, dateTime, insertTo2Tables);
+            TestConversion(dateTime.AddDays(1));
+            dateTime = new DateTime(2018, 2, 1);
+            RunInsertOrUpdate(isBulkOperation, dateTime);
+            TestConversion(dateTime.AddDays(1));
+            dateTime = new DateTime(2018, 3, 1);
+            RunUpdate(isBulkOperation, dateTime);
+            TestConversion(dateTime.AddDays(1));
             RunDelete(isBulkOperation);
         }
 
@@ -29,7 +36,7 @@ namespace EFCore.BulkExtensions.Tests
             Debug.WriteLine(percentage);
         }
 
-        private void RunInsert(bool isBulkOperation, bool insertTo2Tables = false)
+        private void RunInsert(bool isBulkOperation, DateTime dateTime, bool insertTo2Tables = false)
         {
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
@@ -44,8 +51,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info " + Guid.NewGuid().ToString().Substring(0, 3),
                         Quantity = i % 10,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = DateTime.Now,
-                        ConvertedTime = DateTime.Now
+                        TimeUpdated = dateTime,
+                        ConvertedTime = dateTime
                     });
                 }
                 if (insertTo2Tables)
@@ -73,11 +80,13 @@ namespace EFCore.BulkExtensions.Tests
                         {
                             context.BulkInsert(
                                 entities,
-                                new BulkConfig {
+                                new BulkConfig
+                                {
                                     PreserveInsertOrder = true,
                                     SetOutputIdentity = true,
                                     BatchSize = 4000
-                                    ,UseTempDB = true
+                                    ,
+                                    UseTempDB = true
                                 },
                                 (a) => WriteProgress(a)
                             );
@@ -109,12 +118,11 @@ namespace EFCore.BulkExtensions.Tests
             }
         }
 
-        private void RunInsertOrUpdate(bool isBulkOperation)
+        private void RunInsertOrUpdate(bool isBulkOperation, DateTime dateTime)
         {
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
                 var entities = new List<Item>();
-                var dateTimeNow = DateTime.Now;
                 for (int i = 2; i <= entitiesNumber; i += 2)
                 {
                     entities.Add(new Item
@@ -124,8 +132,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info",
                         Quantity = i + 100,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = dateTimeNow,
-                        ConvertedTime = dateTimeNow
+                        TimeUpdated = dateTime,
+                        ConvertedTime = dateTime
                     });
                 }
                 if (isBulkOperation)
@@ -149,7 +157,7 @@ namespace EFCore.BulkExtensions.Tests
             }
         }
 
-        private void RunUpdate(bool isBulkOperation)
+        private void RunUpdate(bool isBulkOperation, DateTime dateTime)
         {
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
@@ -159,13 +167,15 @@ namespace EFCore.BulkExtensions.Tests
                 {
                     entity.Description = "Desc Update " + counter++;
                     entity.Quantity = entity.Quantity + 1000; // will not be changed since Quantity property is not in config PropertiesToInclude 
+                    entity.ConvertedTime = dateTime;
                 }
                 if (isBulkOperation)
                 {
                     context.BulkUpdate(
-                        entities, new BulkConfig {
+                        entities, new BulkConfig
+                        {
                             UpdateByProperties = new List<string> { nameof(Item.Name) },
-                            PropertiesToInclude = new List<string> { nameof(Item.Description) }
+                            PropertiesToInclude = new List<string> { nameof(Item.Description), nameof(Item.ConvertedTime) }
                         }
                     );
                 }
@@ -216,6 +226,29 @@ namespace EFCore.BulkExtensions.Tests
                 // Resets AutoIncrement
                 context.Database.ExecuteSqlCommand("DBCC CHECKIDENT ('dbo.[" + nameof(Item) + "]', RESEED, 0);"); // can NOT use $"...{nameof(Item)..." beacause it get parameterized
                 //context.Database.ExecuteSqlCommand($"TRUNCATE TABLE {nameof(Item)};"); // can NOT work when there is ForeignKey - ItemHistoryId
+            }
+        }
+
+        private void TestConversion(DateTime dateTime)
+        {
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var conn = context.Database.GetDbConnection();
+                if (conn.State != ConnectionState.Open)
+                    conn.Open();
+
+                using (var command = conn.CreateCommand())
+                {
+                    command.CommandText = $"select top 1 * from {nameof(Item)} order by {nameof(Item.ItemId)} desc";
+                    var reader = command.ExecuteReader();
+                    reader.Read();
+                    var row = new Item()
+                    {
+                        ConvertedTime = reader.Field<DateTime>(nameof(Item.ConvertedTime)),
+                    };
+                    if (row.ConvertedTime != dateTime)
+                        throw new Exception($"The '{nameof(Item.ConvertedTime)}' was not converted properly");
+                }
             }
         }
     }

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -38,7 +38,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info " + Guid.NewGuid().ToString().Substring(0, 3),
                         Quantity = i % 10,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = DateTime.Now
+                        TimeUpdated = DateTime.Now,
+                        ConvertedTime = DateTime.Now,
                     });
                 }
                 if (isBulkOperation)
@@ -100,7 +101,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info",
                         Quantity = i,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = dateTimeNow
+                        TimeUpdated = dateTimeNow,
+                        ConvertedTime = dateTimeNow
                     });
                 }
                 if (isBulkOperation)

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -29,6 +29,11 @@ namespace EFCore.BulkExtensions.Tests
 
             modelBuilder.Entity<UserRole>().HasKey(a => new { a.UserId, a.RoleId });
 
+            modelBuilder.Entity<Item>(entity =>
+            {
+                entity.Property(p => p.ConvertedTime).HasConversion((value) => value.AddDays(1), (value) => value.AddDays(-1));
+            });
+
             // For testing Global Filter
             //modelBuilder.Entity<Item>().HasQueryFilter(p => p.Description != "1234");
         }
@@ -40,7 +45,7 @@ namespace EFCore.BulkExtensions.Tests
         {
             var builder = new DbContextOptionsBuilder<TestContext>();
             var databaseName = nameof(EFCoreBulkTest);
-            var connectionString = $"Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
+            var connectionString = $"Server=(localdb)\\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
             builder.UseSqlServer(connectionString); // Can NOT Test with UseInMemoryDb (Exception: Relational-specific methods can only be used when the context is using a relational)
             return builder.Options;
         }
@@ -60,17 +65,19 @@ namespace EFCore.BulkExtensions.Tests
     public class Item
     {
         public int ItemId { get; set; }
-        
+
         public string Name { get; set; }
-        
+
         public string Description { get; set; }
 
         public int Quantity { get; set; }
-        
+
         public decimal? Price { get; set; }
 
         public DateTime TimeUpdated { get; set; }
-        
+
+        public DateTime ConvertedTime { get; set; }
+
         [Timestamp]
         public byte[] VersionChange { get; set; }
 
@@ -105,7 +112,7 @@ namespace EFCore.BulkExtensions.Tests
     public abstract class Person
     {
         public int PersonId { get; set; }
-	
+
         public string Name { get; set; }
     }
     public class Instructor : Person

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -45,7 +45,8 @@ namespace EFCore.BulkExtensions.Tests
         {
             var builder = new DbContextOptionsBuilder<TestContext>();
             var databaseName = nameof(EFCoreBulkTest);
-            var connectionString = $"Server=(localdb)\\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
+            //var connectionString = $"Server=(localdb)\\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
+            var connectionString = $"Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
             builder.UseSqlServer(connectionString); // Can NOT Test with UseInMemoryDb (Exception: Relational-specific methods can only be used when the context is using a relational)
             return builder.Options;
         }

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastMember.Signed" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="FastMember.Signed" Version="1.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.1.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/EFCore.BulkExtensions/ObjectReaderEx.cs
+++ b/EFCore.BulkExtensions/ObjectReaderEx.cs
@@ -4,28 +4,32 @@ using System.Collections.Generic;
 using System.Reflection;
 using FastMember;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EFCore.BulkExtensions
 {
     internal class ObjectReaderEx : ObjectReader // Overridden to fix ShadowProperties in FastMember library
     {
         private readonly HashSet<string> _shadowProperties;
+        private readonly Dictionary<string, ValueConverter> _convertibleProperties;
         private readonly DbContext _context;
         private string[] _members;
         private FieldInfo _current;
 
-        public ObjectReaderEx(Type type, IEnumerable source, HashSet<string> shadowProperties, DbContext context, params string[] members) : base(type, source, members)
+        public ObjectReaderEx(Type type, IEnumerable source, HashSet<string> shadowProperties, Dictionary<string, ValueConverter> convertibleProperties, DbContext context, params string[] members) : base(type, source, members)
         {
             _shadowProperties = shadowProperties;
+            _convertibleProperties = convertibleProperties;
             _context = context;
             _members = members;
             _current = typeof(ObjectReader).GetField("current", BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
-        public static ObjectReader Create<T>(IEnumerable<T> source, HashSet<string> shadowProperties, DbContext context, params string[] members)
+        public static ObjectReader Create<T>(IEnumerable<T> source, HashSet<string> shadowProperties, Dictionary<string, ValueConverter> convertibleProperties, DbContext context, params string[] members)
         {
             bool hasShadowProp = shadowProperties.Count > 0;
-            return hasShadowProp ? (ObjectReader)new ObjectReaderEx(typeof(T), source, shadowProperties, context, members) : ObjectReader.Create(source, members);
+            bool hasConvertibleProperties = convertibleProperties.Keys.Count > 0;
+            return (hasShadowProp || hasConvertibleProperties) ? (ObjectReader)new ObjectReaderEx(typeof(T), source, shadowProperties, convertibleProperties, context, members) : ObjectReader.Create(source, members);
         }
 
         public override object this[string name]
@@ -36,6 +40,12 @@ namespace EFCore.BulkExtensions
                 {
                     var current = _current.GetValue(this);
                     return _context.Entry(current).Property(name).CurrentValue;
+                }
+                else if (_convertibleProperties.TryGetValue(name, out var converter))
+                {
+                    var current = _current.GetValue(this);
+                    var currentValue = _context.Entry(current).Property(name).CurrentValue;
+                    return converter.ConvertToProvider(currentValue);
                 }
                 return base[name];
             }

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -28,7 +28,7 @@ namespace EFCore.BulkExtensions
                 using (var sqlBulkCopy = GetSqlBulkCopy(sqlConnection, transaction, tableInfo.BulkConfig.SqlBulkCopyOptions))
                 {
                     tableInfo.SetSqlBulkCopyConfig(sqlBulkCopy, entities, progress);
-                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
+                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, tableInfo.ConvertibleProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
                     {
                         sqlBulkCopy.WriteToServer(reader);
                     }
@@ -52,7 +52,7 @@ namespace EFCore.BulkExtensions
                 using (var sqlBulkCopy = GetSqlBulkCopy(sqlConnection, transaction, tableInfo.BulkConfig.SqlBulkCopyOptions))
                 {
                     tableInfo.SetSqlBulkCopyConfig(sqlBulkCopy, entities, progress);
-                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
+                    using (var reader = ObjectReaderEx.Create(entities, tableInfo.ShadowProperties, tableInfo.ConvertibleProperties, context, tableInfo.PropertyColumnNamesDict.Keys.ToArray()))
                     {
                         await sqlBulkCopy.WriteToServerAsync(reader).ConfigureAwait(false);
                     }
@@ -66,7 +66,7 @@ namespace EFCore.BulkExtensions
                 }
             }
         }
-        
+
         public static void Merge<T>(DbContext context, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal> progress) where T : class
         {
             tableInfo.InsertToTempTable = true;

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -10,6 +10,7 @@ using FastMember;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace EFCore.BulkExtensions
 {
@@ -35,6 +36,7 @@ namespace EFCore.BulkExtensions
         public BulkConfig BulkConfig { get; set; }
         public Dictionary<string, string> PropertyColumnNamesDict { get; set; } = new Dictionary<string, string>();
         public HashSet<string> ShadowProperties { get; set; } = new HashSet<string>();
+        public Dictionary<string, ValueConverter> ConvertibleProperties { get; set; } = new Dictionary<string, ValueConverter>();
         public string TimeStampColumn { get; set; }
 
         public static TableInfo CreateInstance<T>(DbContext context, IList<T> entities, OperationType operationType, BulkConfig bulkConfig)
@@ -77,10 +79,10 @@ namespace EFCore.BulkExtensions
             var timeStampProperties = allProperties.Where(a => a.IsConcurrencyToken == true && a.ValueGenerated == ValueGenerated.OnAddOrUpdate && a.BeforeSaveBehavior == PropertySaveBehavior.Ignore);
             TimeStampColumn = timeStampProperties.FirstOrDefault()?.Relational().ColumnName; // expected to be only One
             var properties = allProperties.Except(timeStampProperties);
-            
+
             bool AreSpecifiedPropertiesToInclude = BulkConfig.PropertiesToInclude?.Count() > 0;
             bool AreSpecifiedPropertiesToExclude = BulkConfig.PropertiesToExclude?.Count() > 0;
-            
+
             if (AreSpecifiedPropertiesToInclude)
             {
                 if (AreSpecifiedUpdateByProperties) // Adds UpdateByProperties to PropertyToInclude if they are not already explicitly listed
@@ -95,7 +97,7 @@ namespace EFCore.BulkExtensions
                 }
                 else // Adds PrimaryKeys to PropertyToInclude if they are not already explicitly listed
                 {
-                    foreach (var primaryKey in PrimaryKeys) 
+                    foreach (var primaryKey in PrimaryKeys)
                     {
                         if (!BulkConfig.PropertiesToInclude.Contains(primaryKey))
                         {
@@ -123,6 +125,8 @@ namespace EFCore.BulkExtensions
             {
                 PropertyColumnNamesDict = properties.ToDictionary(a => a.Name, b => b.Relational().ColumnName);
                 ShadowProperties = new HashSet<string>(properties.Where(p => p.IsShadowProperty).Select(p => p.Relational().ColumnName));
+                foreach (var property in properties.Where(p => p.GetValueConverter() != null))
+                    ConvertibleProperties.Add(property.Relational().ColumnName, property.GetValueConverter());
             }
         }
 


### PR DESCRIPTION
Added support for ValueConverters and updated the existing unit tests to accommodate a property that had a conversion on it. See issue #39 