### PR TITLE
Update BatchUtil.cs

### DIFF
--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -85,23 +85,26 @@ namespace EFCore.BulkExtensions
                 var pArray = propertyName.Split(new char[] { '.' });
                 Type lastType = updateValuesType;
                 PropertyInfo property = lastType.GetProperty(pArray[0]);
-                object propertyUpdateValue = property.GetValue(updateValues);
-                object propertyDefaultValue = property.GetValue(defaultValues);
-                for (int i = 1; i < pArray.Length; i++)
+                if (property != null)
                 {
-                    lastType = property.PropertyType;
-                    property = lastType.GetProperty(pArray[i]);
-                    propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
-                    var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
-                    propertyDefaultValue = property.GetValue(lastDefaultValues);
-                }
+                    object propertyUpdateValue = property.GetValue(updateValues);
+                    object propertyDefaultValue = property.GetValue(defaultValues);
+                    for (int i = 1; i < pArray.Length; i++)
+                    {
+                        lastType = property.PropertyType;
+                        property = lastType.GetProperty(pArray[i]);
+                        propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
+                        var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
+                        propertyDefaultValue = property.GetValue(lastDefaultValues);
+                    }
 
-                bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
-                if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
-                {
-                    sql += $"[{columnName}] = @{columnName}, ";
-                    propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
-                    parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
+                    bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
+                    if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
+                    {
+                        sql += $"[{columnName}] = @{columnName}, ";
+                        propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
+                        parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
+                    }
                 }
             }
             if (String.IsNullOrEmpty(sql))


### PR DESCRIPTION
In some situations, the table may contain columns that you do not want to have in the model. For example, LastUpdate, RowVersion. Such columns can be filled by triggers or by the engine.

In this case, the GetSqlFragment method throws an exception (with the exception of a null reference) because it has no equivalent property to that column in the entity model.

To reproduce this exception, add RowVersion column to a table and try to update any column for the entity corresponding to this table by BatchUpdate method.