### PR TITLE
Solves issue #177

### DIFF
--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -12,226 +12,226 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace EFCore.BulkExtensions
 {
-	static class BatchUtil
-	{
-		// In comment are Examples of how SqlQuery is changed for Sql Batch
+    static class BatchUtil
+    {
+        // In comment are Examples of how SqlQuery is changed for Sql Batch
 
-		// SELECT [a].[Column1], [a].[Column2], .../r/n
-		// FROM [Table] AS [a]/r/n
-		// WHERE [a].[Column] = FilterValue
-		// --
-		// DELETE [a]
-		// FROM [Table] AS [a]
-		// WHERE [a].[Columns] = FilterValues
-		public static (string, List<SqlParameter>) GetSqlDelete<T>(IQueryable<T> query) where T : class
-		{
-			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
-			return ($"DELETE [{tableAlias}]{sql}", new List<SqlParameter>(innerParameters));
-		}
+        // SELECT [a].[Column1], [a].[Column2], .../r/n
+        // FROM [Table] AS [a]/r/n
+        // WHERE [a].[Column] = FilterValue
+        // --
+        // DELETE [a]
+        // FROM [Table] AS [a]
+        // WHERE [a].[Columns] = FilterValues
+        public static (string, List<SqlParameter>) GetSqlDelete<T>(IQueryable<T> query) where T : class
+        {
+            (string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+            return ($"DELETE [{tableAlias}]{sql}", new List<SqlParameter>(innerParameters));
+        }
 
-		// SELECT [a].[Column1], [a].[Column2], .../r/n
-		// FROM [Table] AS [a]/r/n
-		// WHERE [a].[Column] = FilterValue
-		// --
-		// UPDATE [a] SET [UpdateColumns] = N'updateValues'
-		// FROM [Table] AS [a]
-		// WHERE [a].[Columns] = FilterValues
-		public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, DbContext context, T updateValues, List<string> updateColumns) where T : class, new()
-		{
-			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
-			var sqlParameters = new List<SqlParameter>(innerParameters);
-			string sqlSET = GetSqlSetSegment(context, updateValues, updateColumns, sqlParameters);
-			return ($"UPDATE [{tableAlias}] {sqlSET}{sql}", sqlParameters);
-		}
+        // SELECT [a].[Column1], [a].[Column2], .../r/n
+        // FROM [Table] AS [a]/r/n
+        // WHERE [a].[Column] = FilterValue
+        // --
+        // UPDATE [a] SET [UpdateColumns] = N'updateValues'
+        // FROM [Table] AS [a]
+        // WHERE [a].[Columns] = FilterValues
+        public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, DbContext context, T updateValues, List<string> updateColumns) where T : class, new()
+        {
+            (string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+            var sqlParameters = new List<SqlParameter>(innerParameters);
+            string sqlSET = GetSqlSetSegment(context, updateValues, updateColumns, sqlParameters);
+            return ($"UPDATE [{tableAlias}] {sqlSET}{sql}", sqlParameters);
+        }
 
-		/// <summary>
-		/// get Update Sql
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="query"></param>
-		/// <param name="expression"></param>
-		/// <returns></returns>
-		public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, Expression<Func<T, T>> expression) where T : class
-		{
-			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
-			var sqlColumns = new StringBuilder();
-			var sqlParameters = new List<SqlParameter>(innerParameters);
-			var columnNameValueDict = TableInfo.CreateInstance(GetDbContext(query), new List<T>(), OperationType.Read, new BulkConfig()).PropertyColumnNamesDict;
-			CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, ref sqlColumns, ref sqlParameters);
-			return ($"UPDATE [{tableAlias}] SET {sqlColumns.ToString()} {sql}", sqlParameters);
-		}
+        /// <summary>
+        /// get Update Sql
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="query"></param>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, Expression<Func<T, T>> expression) where T : class
+        {
+            (string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+            var sqlColumns = new StringBuilder();
+            var sqlParameters = new List<SqlParameter>(innerParameters);
+            var columnNameValueDict = TableInfo.CreateInstance(GetDbContext(query), new List<T>(), OperationType.Read, new BulkConfig()).PropertyColumnNamesDict;
+            CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, ref sqlColumns, ref sqlParameters);
+            return ($"UPDATE [{tableAlias}] SET {sqlColumns.ToString()} {sql}", sqlParameters);
+        }
 
-		public static (string, string, IEnumerable<SqlParameter>) GetBatchSql<T>(IQueryable<T> query) where T : class
-		{
-			(string sqlQuery, IEnumerable<SqlParameter> innerParameters) = query.ToParametrizedSql();
-			string tableAlias = sqlQuery.Substring(8, sqlQuery.IndexOf("]") - 8);
-			int indexFROM = sqlQuery.IndexOf(Environment.NewLine);
-			string sql = sqlQuery.Substring(indexFROM, sqlQuery.Length - indexFROM);
-			sql = sql.Contains("{") ? sql.Replace("{", "{{") : sql; // Curly brackets have to escaped:
-			sql = sql.Contains("}") ? sql.Replace("}", "}}") : sql; // https://github.com/aspnet/EntityFrameworkCore/issues/8820
-			return (sql, tableAlias, innerParameters);
-		}
+        public static (string, string, IEnumerable<SqlParameter>) GetBatchSql<T>(IQueryable<T> query) where T : class
+        {
+            (string sqlQuery, IEnumerable<SqlParameter> innerParameters) = query.ToParametrizedSql();
+            string tableAlias = sqlQuery.Substring(8, sqlQuery.IndexOf("]") - 8);
+            int indexFROM = sqlQuery.IndexOf(Environment.NewLine);
+            string sql = sqlQuery.Substring(indexFROM, sqlQuery.Length - indexFROM);
+            sql = sql.Contains("{") ? sql.Replace("{", "{{") : sql; // Curly brackets have to escaped:
+            sql = sql.Contains("}") ? sql.Replace("}", "}}") : sql; // https://github.com/aspnet/EntityFrameworkCore/issues/8820
+            return (sql, tableAlias, innerParameters);
+        }
 
-		public static string GetSqlSetSegment<T>(DbContext context, T updateValues, List<string> updateColumns, List<SqlParameter> parameters) where T : class, new()
-		{
-			var tableInfo = TableInfo.CreateInstance<T>(context, new List<T>(), OperationType.Read, new BulkConfig());
-			string sql = string.Empty;
-			Type updateValuesType = typeof(T);
-			var defaultValues = new T();
-			foreach (var propertyNameColumnName in tableInfo.PropertyColumnNamesDict)
-			{
-				string propertyName = propertyNameColumnName.Key;
-				string columnName = propertyNameColumnName.Value;
-				var pArray = propertyName.Split(new char[] { '.' });
-				Type lastType = updateValuesType;
-				PropertyInfo property = lastType.GetProperty(pArray[0]);
-				if (property != null)
-				{
-					object propertyUpdateValue = property.GetValue(updateValues);
-					object propertyDefaultValue = property.GetValue(defaultValues);
-					for (int i = 1; i < pArray.Length; i++)
-					{
-						lastType = property.PropertyType;
-						property = lastType.GetProperty(pArray[i]);
-						propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
-						var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
-						propertyDefaultValue = property.GetValue(lastDefaultValues);
-					}
+        public static string GetSqlSetSegment<T>(DbContext context, T updateValues, List<string> updateColumns, List<SqlParameter> parameters) where T : class, new()
+        {
+            var tableInfo = TableInfo.CreateInstance<T>(context, new List<T>(), OperationType.Read, new BulkConfig());
+            string sql = string.Empty;
+            Type updateValuesType = typeof(T);
+            var defaultValues = new T();
+            foreach (var propertyNameColumnName in tableInfo.PropertyColumnNamesDict)
+            {
+                string propertyName = propertyNameColumnName.Key;
+                string columnName = propertyNameColumnName.Value;
+                var pArray = propertyName.Split(new char[] { '.' });
+                Type lastType = updateValuesType;
+                PropertyInfo property = lastType.GetProperty(pArray[0]);
+                if (property != null)
+                {
+                    object propertyUpdateValue = property.GetValue(updateValues);
+                    object propertyDefaultValue = property.GetValue(defaultValues);
+                    for (int i = 1; i < pArray.Length; i++)
+                    {
+                        lastType = property.PropertyType;
+                        property = lastType.GetProperty(pArray[i]);
+                        propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
+                        var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
+                        propertyDefaultValue = property.GetValue(lastDefaultValues);
+                    }
 
-					bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
-					if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
-					{
-						sql += $"[{columnName}] = @{columnName}, ";
-						propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
-						parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
-					}
-				}
-			}
-			if (String.IsNullOrEmpty(sql))
-			{
-				throw new InvalidOperationException("SET Columns not defined. If one or more columns should be updated to theirs default value use 'updateColumns' argument.");
-			}
-			sql = sql.Remove(sql.Length - 2, 2); // removes last excess comma and space: ", "
-			return $"SET {sql}";
-		}
+                    bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
+                    if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
+                    {
+                        sql += $"[{columnName}] = @{columnName}, ";
+                        propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
+                        parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
+                    }
+                }
+            }
+            if (String.IsNullOrEmpty(sql))
+            {
+                throw new InvalidOperationException("SET Columns not defined. If one or more columns should be updated to theirs default value use 'updateColumns' argument.");
+            }
+            sql = sql.Remove(sql.Length - 2, 2); // removes last excess comma and space: ", "
+            return $"SET {sql}";
+        }
 
-		/// <summary>
-		/// Recursive analytic expression 
-		/// </summary>
-		/// <param name="tableAlias"></param>
-		/// <param name="expression"></param>
-		/// <param name="sqlColumns"></param>
-		/// <param name="sqlParameters"></param>
-		/// <summary>
-		/// Recursive analytic expression 
-		/// </summary>
-		/// <param name="tableAlias"></param>
-		/// <param name="expression"></param>
-		/// <param name="sqlColumns"></param>
-		/// <param name="sqlParameters"></param>
-		public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, ref StringBuilder sqlColumns, ref List<SqlParameter> sqlParameters)
-		{
-			if (expression is MemberInitExpression memberInitExpression)
-			{
-				foreach (var item in memberInitExpression.Bindings)
-				{
-					if (item is MemberAssignment assignment)
-					{
-						if (columnNameValueDict.TryGetValue(assignment.Member.Name, out string value))
-							sqlColumns.Append($" [{tableAlias}].[{value}]");
-						else
-							sqlColumns.Append($" [{tableAlias}].[{assignment.Member.Name}]");
+        /// <summary>
+        /// Recursive analytic expression 
+        /// </summary>
+        /// <param name="tableAlias"></param>
+        /// <param name="expression"></param>
+        /// <param name="sqlColumns"></param>
+        /// <param name="sqlParameters"></param>
+        /// <summary>
+        /// Recursive analytic expression 
+        /// </summary>
+        /// <param name="tableAlias"></param>
+        /// <param name="expression"></param>
+        /// <param name="sqlColumns"></param>
+        /// <param name="sqlParameters"></param>
+        public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, ref StringBuilder sqlColumns, ref List<SqlParameter> sqlParameters)
+        {
+            if (expression is MemberInitExpression memberInitExpression)
+            {
+                foreach (var item in memberInitExpression.Bindings)
+                {
+                    if (item is MemberAssignment assignment)
+                    {
+                        if (columnNameValueDict.TryGetValue(assignment.Member.Name, out string value))
+                            sqlColumns.Append($" [{tableAlias}].[{value}]");
+                        else
+                            sqlColumns.Append($" [{tableAlias}].[{assignment.Member.Name}]");
 
-						sqlColumns.Append(" =");
+                        sqlColumns.Append(" =");
 
-						CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, ref sqlColumns, ref sqlParameters);
+                        CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, ref sqlColumns, ref sqlParameters);
 
-						if (memberInitExpression.Bindings.IndexOf(item) < (memberInitExpression.Bindings.Count - 1))
-							sqlColumns.Append(" ,");
-					}
-				}
-			}
-			else if (expression is MemberExpression memberExpression && memberExpression.Expression is ParameterExpression)
-			{
-				if (columnNameValueDict.TryGetValue(memberExpression.Member.Name, out string value))
-					sqlColumns.Append($" [{tableAlias}].[{value}]");
-				else
-					sqlColumns.Append($" [{tableAlias}].[{memberExpression.Member.Name}]");
-			}
-			else if (expression is ConstantExpression constantExpression)
-			{
-				var parmName = $"param_{sqlParameters.Count}";
-				sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value));
-				sqlColumns.Append($" @{parmName}");
-			}
-			else if (expression is UnaryExpression unaryExpression)
-			{
-				switch (unaryExpression.NodeType)
-				{
-					case ExpressionType.Convert:
-						CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
-						break;
-					case ExpressionType.Not:
-						sqlColumns.Append(" ~");//this way only for SQL Server 
-						CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
-						break;
-					default: break;
-				}
-			}
-			else if (expression is BinaryExpression binaryExpression)
-			{
-				CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, ref sqlColumns, ref sqlParameters);
+                        if (memberInitExpression.Bindings.IndexOf(item) < (memberInitExpression.Bindings.Count - 1))
+                            sqlColumns.Append(" ,");
+                    }
+                }
+            }
+            else if (expression is MemberExpression memberExpression && memberExpression.Expression is ParameterExpression)
+            {
+                if (columnNameValueDict.TryGetValue(memberExpression.Member.Name, out string value))
+                    sqlColumns.Append($" [{tableAlias}].[{value}]");
+                else
+                    sqlColumns.Append($" [{tableAlias}].[{memberExpression.Member.Name}]");
+            }
+            else if (expression is ConstantExpression constantExpression)
+            {
+                var parmName = $"param_{sqlParameters.Count}";
+                sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value));
+                sqlColumns.Append($" @{parmName}");
+            }
+            else if (expression is UnaryExpression unaryExpression)
+            {
+                switch (unaryExpression.NodeType)
+                {
+                    case ExpressionType.Convert:
+                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+                        break;
+                    case ExpressionType.Not:
+                        sqlColumns.Append(" ~");//this way only for SQL Server 
+                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+                        break;
+                    default: break;
+                }
+            }
+            else if (expression is BinaryExpression binaryExpression)
+            {
+                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, ref sqlColumns, ref sqlParameters);
 
-				switch (binaryExpression.NodeType)
-				{
-					case ExpressionType.Add:
-						sqlColumns.Append(" +");
-						break;
-					case ExpressionType.Divide:
-						sqlColumns.Append(" /");
-						break;
-					case ExpressionType.Multiply:
-						sqlColumns.Append(" *");
-						break;
-					case ExpressionType.Subtract:
-						sqlColumns.Append(" -");
-						break;
-					case ExpressionType.And:
-						sqlColumns.Append(" &");
-						break;
-					case ExpressionType.Or:
-						sqlColumns.Append(" |");
-						break;
-					case ExpressionType.ExclusiveOr:
-						sqlColumns.Append(" ^");
-						break;
-					default: break;
-				}
+                switch (binaryExpression.NodeType)
+                {
+                    case ExpressionType.Add:
+                        sqlColumns.Append(" +");
+                        break;
+                    case ExpressionType.Divide:
+                        sqlColumns.Append(" /");
+                        break;
+                    case ExpressionType.Multiply:
+                        sqlColumns.Append(" *");
+                        break;
+                    case ExpressionType.Subtract:
+                        sqlColumns.Append(" -");
+                        break;
+                    case ExpressionType.And:
+                        sqlColumns.Append(" &");
+                        break;
+                    case ExpressionType.Or:
+                        sqlColumns.Append(" |");
+                        break;
+                    case ExpressionType.ExclusiveOr:
+                        sqlColumns.Append(" ^");
+                        break;
+                    default: break;
+                }
 
-				CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, ref sqlColumns, ref sqlParameters);
-			}
-			else
-			{
-				var value = Expression.Lambda(expression).Compile().DynamicInvoke();
-				var parmName = $"param_{sqlParameters.Count}";
-				sqlParameters.Add(new SqlParameter(parmName, value));
-				sqlColumns.Append($" @{parmName}");
-			}
-		}
+                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, ref sqlColumns, ref sqlParameters);
+            }
+            else
+            {
+                var value = Expression.Lambda(expression).Compile().DynamicInvoke();
+                var parmName = $"param_{sqlParameters.Count}";
+                sqlParameters.Add(new SqlParameter(parmName, value));
+                sqlColumns.Append($" @{parmName}");
+            }
+        }
 
 
-		public static DbContext GetDbContext(IQueryable query)
-		{
-			var bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
-			var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags).GetValue(query.Provider);
-			var queryContextFactory = queryCompiler.GetType().GetField("_queryContextFactory", bindingFlags).GetValue(queryCompiler);
+        public static DbContext GetDbContext(IQueryable query)
+        {
+            var bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
+            var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags).GetValue(query.Provider);
+            var queryContextFactory = queryCompiler.GetType().GetField("_queryContextFactory", bindingFlags).GetValue(queryCompiler);
 
-			var dependencies = typeof(RelationalQueryContextFactory).GetProperty("Dependencies", bindingFlags).GetValue(queryContextFactory);
-			var queryContextDependencies = typeof(DbContext).Assembly.GetType(typeof(QueryContextDependencies).FullName);
-			var stateManagerProperty = queryContextDependencies.GetProperty("StateManager", bindingFlags | BindingFlags.Public).GetValue(dependencies);
-			var stateManager = (IStateManager)stateManagerProperty;
+            var dependencies = typeof(RelationalQueryContextFactory).GetProperty("Dependencies", bindingFlags).GetValue(queryContextFactory);
+            var queryContextDependencies = typeof(DbContext).Assembly.GetType(typeof(QueryContextDependencies).FullName);
+            var stateManagerProperty = queryContextDependencies.GetProperty("StateManager", bindingFlags | BindingFlags.Public).GetValue(dependencies);
+            var stateManager = (IStateManager)stateManagerProperty;
 
-			return stateManager.Context;
-		}
-	}
+            return stateManager.Context;
+        }
+    }
 }

--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -12,226 +12,226 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace EFCore.BulkExtensions
 {
-    static class BatchUtil
-    {
-        // In comment are Examples of how SqlQuery is changed for Sql Batch
+	static class BatchUtil
+	{
+		// In comment are Examples of how SqlQuery is changed for Sql Batch
 
-        // SELECT [a].[Column1], [a].[Column2], .../r/n
-        // FROM [Table] AS [a]/r/n
-        // WHERE [a].[Column] = FilterValue
-        // --
-        // DELETE [a]
-        // FROM [Table] AS [a]
-        // WHERE [a].[Columns] = FilterValues
-        public static string GetSqlDelete<T>(IQueryable<T> query) where T : class
-        {
-            (string sql, string tableAlias) = GetBatchSql(query);
-            return $"DELETE [{tableAlias}]{sql}";
-        }
+		// SELECT [a].[Column1], [a].[Column2], .../r/n
+		// FROM [Table] AS [a]/r/n
+		// WHERE [a].[Column] = FilterValue
+		// --
+		// DELETE [a]
+		// FROM [Table] AS [a]
+		// WHERE [a].[Columns] = FilterValues
+		public static (string, List<SqlParameter>) GetSqlDelete<T>(IQueryable<T> query) where T : class
+		{
+			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+			return ($"DELETE [{tableAlias}]{sql}", new List<SqlParameter>(innerParameters));
+		}
 
-        // SELECT [a].[Column1], [a].[Column2], .../r/n
-        // FROM [Table] AS [a]/r/n
-        // WHERE [a].[Column] = FilterValue
-        // --
-        // UPDATE [a] SET [UpdateColumns] = N'updateValues'
-        // FROM [Table] AS [a]
-        // WHERE [a].[Columns] = FilterValues
-        public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, DbContext context, T updateValues, List<string> updateColumns) where T : class, new()
-        {
-            (string sql, string tableAlias) = GetBatchSql(query);
-            var sqlParameters = new List<SqlParameter>();
-            string sqlSET = GetSqlSetSegment(context, updateValues, updateColumns, sqlParameters);
-            return ($"UPDATE [{tableAlias}] {sqlSET}{sql}", sqlParameters);
-        }
+		// SELECT [a].[Column1], [a].[Column2], .../r/n
+		// FROM [Table] AS [a]/r/n
+		// WHERE [a].[Column] = FilterValue
+		// --
+		// UPDATE [a] SET [UpdateColumns] = N'updateValues'
+		// FROM [Table] AS [a]
+		// WHERE [a].[Columns] = FilterValues
+		public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, DbContext context, T updateValues, List<string> updateColumns) where T : class, new()
+		{
+			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+			var sqlParameters = new List<SqlParameter>(innerParameters);
+			string sqlSET = GetSqlSetSegment(context, updateValues, updateColumns, sqlParameters);
+			return ($"UPDATE [{tableAlias}] {sqlSET}{sql}", sqlParameters);
+		}
 
-        /// <summary>
-        /// get Update Sql
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="query"></param>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, Expression<Func<T, T>> expression) where T : class
-        {
-            (string sql, string tableAlias) = GetBatchSql(query);
-            var sqlColumns = new StringBuilder();
-            var sqlParameters = new List<SqlParameter>();
-            var columnNameValueDict = TableInfo.CreateInstance(GetDbContext(query), new List<T>(), OperationType.Read, new BulkConfig()).PropertyColumnNamesDict;
-            CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, ref sqlColumns, ref sqlParameters);
-            return ($"UPDATE [{tableAlias}] SET {sqlColumns.ToString()} {sql}", sqlParameters);
-        }
+		/// <summary>
+		/// get Update Sql
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="query"></param>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		public static (string, List<SqlParameter>) GetSqlUpdate<T>(IQueryable<T> query, Expression<Func<T, T>> expression) where T : class
+		{
+			(string sql, string tableAlias, IEnumerable<SqlParameter> innerParameters) = GetBatchSql(query);
+			var sqlColumns = new StringBuilder();
+			var sqlParameters = new List<SqlParameter>(innerParameters);
+			var columnNameValueDict = TableInfo.CreateInstance(GetDbContext(query), new List<T>(), OperationType.Read, new BulkConfig()).PropertyColumnNamesDict;
+			CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, ref sqlColumns, ref sqlParameters);
+			return ($"UPDATE [{tableAlias}] SET {sqlColumns.ToString()} {sql}", sqlParameters);
+		}
 
-        public static (string, string) GetBatchSql<T>(IQueryable<T> query) where T : class
-        {
-            string sqlQuery = query.ToSql();
-            string tableAlias = sqlQuery.Substring(8, sqlQuery.IndexOf("]") - 8);
-            int indexFROM = sqlQuery.IndexOf(Environment.NewLine);
-            string sql = sqlQuery.Substring(indexFROM, sqlQuery.Length - indexFROM);
-            sql = sql.Contains("{") ? sql.Replace("{", "{{") : sql; // Curly brackets have to escaped:
-            sql = sql.Contains("}") ? sql.Replace("}", "}}") : sql; // https://github.com/aspnet/EntityFrameworkCore/issues/8820
-            return (sql, tableAlias);
-        }
+		public static (string, string, IEnumerable<SqlParameter>) GetBatchSql<T>(IQueryable<T> query) where T : class
+		{
+			(string sqlQuery, IEnumerable<SqlParameter> innerParameters) = query.ToParametrizedSql();
+			string tableAlias = sqlQuery.Substring(8, sqlQuery.IndexOf("]") - 8);
+			int indexFROM = sqlQuery.IndexOf(Environment.NewLine);
+			string sql = sqlQuery.Substring(indexFROM, sqlQuery.Length - indexFROM);
+			sql = sql.Contains("{") ? sql.Replace("{", "{{") : sql; // Curly brackets have to escaped:
+			sql = sql.Contains("}") ? sql.Replace("}", "}}") : sql; // https://github.com/aspnet/EntityFrameworkCore/issues/8820
+			return (sql, tableAlias, innerParameters);
+		}
 
-        public static string GetSqlSetSegment<T>(DbContext context, T updateValues, List<string> updateColumns, List<SqlParameter> parameters) where T : class, new()
-        {
-            var tableInfo = TableInfo.CreateInstance<T>(context, new List<T>(), OperationType.Read, new BulkConfig());
-            string sql = string.Empty;
-            Type updateValuesType = typeof(T);
-            var defaultValues = new T();
-            foreach (var propertyNameColumnName in tableInfo.PropertyColumnNamesDict)
-            {
-                string propertyName = propertyNameColumnName.Key;
-                string columnName = propertyNameColumnName.Value;
-                var pArray = propertyName.Split(new char[] { '.' });
-                Type lastType = updateValuesType;
-                PropertyInfo property = lastType.GetProperty(pArray[0]);
-                if (property != null)
-                {
-                    object propertyUpdateValue = property.GetValue(updateValues);
-                    object propertyDefaultValue = property.GetValue(defaultValues);
-                    for (int i = 1; i < pArray.Length; i++)
-                    {
-                        lastType = property.PropertyType;
-                        property = lastType.GetProperty(pArray[i]);
-                        propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
-                        var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
-                        propertyDefaultValue = property.GetValue(lastDefaultValues);
-                    }
+		public static string GetSqlSetSegment<T>(DbContext context, T updateValues, List<string> updateColumns, List<SqlParameter> parameters) where T : class, new()
+		{
+			var tableInfo = TableInfo.CreateInstance<T>(context, new List<T>(), OperationType.Read, new BulkConfig());
+			string sql = string.Empty;
+			Type updateValuesType = typeof(T);
+			var defaultValues = new T();
+			foreach (var propertyNameColumnName in tableInfo.PropertyColumnNamesDict)
+			{
+				string propertyName = propertyNameColumnName.Key;
+				string columnName = propertyNameColumnName.Value;
+				var pArray = propertyName.Split(new char[] { '.' });
+				Type lastType = updateValuesType;
+				PropertyInfo property = lastType.GetProperty(pArray[0]);
+				if (property != null)
+				{
+					object propertyUpdateValue = property.GetValue(updateValues);
+					object propertyDefaultValue = property.GetValue(defaultValues);
+					for (int i = 1; i < pArray.Length; i++)
+					{
+						lastType = property.PropertyType;
+						property = lastType.GetProperty(pArray[i]);
+						propertyUpdateValue = propertyUpdateValue != null ? property.GetValue(propertyUpdateValue) : propertyUpdateValue;
+						var lastDefaultValues = lastType.Assembly.CreateInstance(lastType.FullName);
+						propertyDefaultValue = property.GetValue(lastDefaultValues);
+					}
 
-                    bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
-                    if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
-                    {
-                        sql += $"[{columnName}] = @{columnName}, ";
-                        propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
-                        parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
-                    }
-                }
-            }
-            if (String.IsNullOrEmpty(sql))
-            {
-                throw new InvalidOperationException("SET Columns not defined. If one or more columns should be updated to theirs default value use 'updateColumns' argument.");
-            }
-            sql = sql.Remove(sql.Length - 2, 2); // removes last excess comma and space: ", "
-            return $"SET {sql}";
-        }
+					bool isDifferentFromDefault = propertyUpdateValue != null && propertyUpdateValue?.ToString() != propertyDefaultValue?.ToString();
+					if (isDifferentFromDefault || (updateColumns != null && updateColumns.Contains(propertyName)))
+					{
+						sql += $"[{columnName}] = @{columnName}, ";
+						propertyUpdateValue = propertyUpdateValue ?? DBNull.Value;
+						parameters.Add(new SqlParameter($"@{columnName}", propertyUpdateValue));
+					}
+				}
+			}
+			if (String.IsNullOrEmpty(sql))
+			{
+				throw new InvalidOperationException("SET Columns not defined. If one or more columns should be updated to theirs default value use 'updateColumns' argument.");
+			}
+			sql = sql.Remove(sql.Length - 2, 2); // removes last excess comma and space: ", "
+			return $"SET {sql}";
+		}
 
-        /// <summary>
-        /// Recursive analytic expression 
-        /// </summary>
-        /// <param name="tableAlias"></param>
-        /// <param name="expression"></param>
-        /// <param name="sqlColumns"></param>
-        /// <param name="sqlParameters"></param>
-        /// <summary>
-        /// Recursive analytic expression 
-        /// </summary>
-        /// <param name="tableAlias"></param>
-        /// <param name="expression"></param>
-        /// <param name="sqlColumns"></param>
-        /// <param name="sqlParameters"></param>
-        public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, ref StringBuilder sqlColumns, ref List<SqlParameter> sqlParameters)
-        {
-            if (expression is MemberInitExpression memberInitExpression)
-            {
-                foreach (var item in memberInitExpression.Bindings)
-                {
-                    if (item is MemberAssignment assignment)
-                    {
-                        if (columnNameValueDict.TryGetValue(assignment.Member.Name, out string value))
-                            sqlColumns.Append($" [{tableAlias}].[{value}]");
-                        else
-                            sqlColumns.Append($" [{tableAlias}].[{assignment.Member.Name}]");
+		/// <summary>
+		/// Recursive analytic expression 
+		/// </summary>
+		/// <param name="tableAlias"></param>
+		/// <param name="expression"></param>
+		/// <param name="sqlColumns"></param>
+		/// <param name="sqlParameters"></param>
+		/// <summary>
+		/// Recursive analytic expression 
+		/// </summary>
+		/// <param name="tableAlias"></param>
+		/// <param name="expression"></param>
+		/// <param name="sqlColumns"></param>
+		/// <param name="sqlParameters"></param>
+		public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, ref StringBuilder sqlColumns, ref List<SqlParameter> sqlParameters)
+		{
+			if (expression is MemberInitExpression memberInitExpression)
+			{
+				foreach (var item in memberInitExpression.Bindings)
+				{
+					if (item is MemberAssignment assignment)
+					{
+						if (columnNameValueDict.TryGetValue(assignment.Member.Name, out string value))
+							sqlColumns.Append($" [{tableAlias}].[{value}]");
+						else
+							sqlColumns.Append($" [{tableAlias}].[{assignment.Member.Name}]");
 
-                        sqlColumns.Append(" =");
+						sqlColumns.Append(" =");
 
-                        CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, ref sqlColumns, ref sqlParameters);
+						CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, ref sqlColumns, ref sqlParameters);
 
-                        if (memberInitExpression.Bindings.IndexOf(item) < (memberInitExpression.Bindings.Count - 1))
-                            sqlColumns.Append(" ,");
-                    }
-                }
-            }
-            else if (expression is MemberExpression memberExpression && memberExpression.Expression is ParameterExpression)
-            {
-                if (columnNameValueDict.TryGetValue(memberExpression.Member.Name, out string value))
-                    sqlColumns.Append($" [{tableAlias}].[{value}]");
-                else
-                    sqlColumns.Append($" [{tableAlias}].[{memberExpression.Member.Name}]");
-            }
-            else if (expression is ConstantExpression constantExpression)
-            {
-                var parmName = $"param_{sqlParameters.Count}";
-                sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value));
-                sqlColumns.Append($" @{parmName}");
-            }
-            else if (expression is UnaryExpression unaryExpression)
-            {
-                switch (unaryExpression.NodeType)
-                {
-                    case ExpressionType.Convert:
-                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
-                        break;
-                    case ExpressionType.Not:
-                        sqlColumns.Append(" ~");//this way only for SQL Server 
-                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
-                        break;
-                    default: break;
-                }
-            }
-            else if (expression is BinaryExpression binaryExpression)
-            {
-                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, ref sqlColumns, ref sqlParameters);
+						if (memberInitExpression.Bindings.IndexOf(item) < (memberInitExpression.Bindings.Count - 1))
+							sqlColumns.Append(" ,");
+					}
+				}
+			}
+			else if (expression is MemberExpression memberExpression && memberExpression.Expression is ParameterExpression)
+			{
+				if (columnNameValueDict.TryGetValue(memberExpression.Member.Name, out string value))
+					sqlColumns.Append($" [{tableAlias}].[{value}]");
+				else
+					sqlColumns.Append($" [{tableAlias}].[{memberExpression.Member.Name}]");
+			}
+			else if (expression is ConstantExpression constantExpression)
+			{
+				var parmName = $"param_{sqlParameters.Count}";
+				sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value));
+				sqlColumns.Append($" @{parmName}");
+			}
+			else if (expression is UnaryExpression unaryExpression)
+			{
+				switch (unaryExpression.NodeType)
+				{
+					case ExpressionType.Convert:
+						CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+						break;
+					case ExpressionType.Not:
+						sqlColumns.Append(" ~");//this way only for SQL Server 
+						CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+						break;
+					default: break;
+				}
+			}
+			else if (expression is BinaryExpression binaryExpression)
+			{
+				CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, ref sqlColumns, ref sqlParameters);
 
-                switch (binaryExpression.NodeType)
-                {
-                    case ExpressionType.Add:
-                        sqlColumns.Append(" +");
-                        break;
-                    case ExpressionType.Divide:
-                        sqlColumns.Append(" /");
-                        break;
-                    case ExpressionType.Multiply:
-                        sqlColumns.Append(" *");
-                        break;
-                    case ExpressionType.Subtract:
-                        sqlColumns.Append(" -");
-                        break;
-                    case ExpressionType.And:
-                        sqlColumns.Append(" &");
-                        break;
-                    case ExpressionType.Or:
-                        sqlColumns.Append(" |");
-                        break;
-                    case ExpressionType.ExclusiveOr:
-                        sqlColumns.Append(" ^");
-                        break;
-                    default: break;
-                }
+				switch (binaryExpression.NodeType)
+				{
+					case ExpressionType.Add:
+						sqlColumns.Append(" +");
+						break;
+					case ExpressionType.Divide:
+						sqlColumns.Append(" /");
+						break;
+					case ExpressionType.Multiply:
+						sqlColumns.Append(" *");
+						break;
+					case ExpressionType.Subtract:
+						sqlColumns.Append(" -");
+						break;
+					case ExpressionType.And:
+						sqlColumns.Append(" &");
+						break;
+					case ExpressionType.Or:
+						sqlColumns.Append(" |");
+						break;
+					case ExpressionType.ExclusiveOr:
+						sqlColumns.Append(" ^");
+						break;
+					default: break;
+				}
 
-                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, ref sqlColumns, ref sqlParameters);
-            }
-            else
-            {
-                var value = Expression.Lambda(expression).Compile().DynamicInvoke();
-                var parmName = $"param_{sqlParameters.Count}";
-                sqlParameters.Add(new SqlParameter(parmName, value));
-                sqlColumns.Append($" @{parmName}");
-            }
-        }
+				CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, ref sqlColumns, ref sqlParameters);
+			}
+			else
+			{
+				var value = Expression.Lambda(expression).Compile().DynamicInvoke();
+				var parmName = $"param_{sqlParameters.Count}";
+				sqlParameters.Add(new SqlParameter(parmName, value));
+				sqlColumns.Append($" @{parmName}");
+			}
+		}
 
 
-        public static DbContext GetDbContext(IQueryable query)
-        {
-            var bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
-            var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags).GetValue(query.Provider);
-            var queryContextFactory = queryCompiler.GetType().GetField("_queryContextFactory", bindingFlags).GetValue(queryCompiler);
+		public static DbContext GetDbContext(IQueryable query)
+		{
+			var bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
+			var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags).GetValue(query.Provider);
+			var queryContextFactory = queryCompiler.GetType().GetField("_queryContextFactory", bindingFlags).GetValue(queryCompiler);
 
-            var dependencies = typeof(RelationalQueryContextFactory).GetProperty("Dependencies", bindingFlags).GetValue(queryContextFactory);
-            var queryContextDependencies = typeof(DbContext).Assembly.GetType(typeof(QueryContextDependencies).FullName);
-            var stateManagerProperty = queryContextDependencies.GetProperty("StateManager", bindingFlags | BindingFlags.Public).GetValue(dependencies);
-            var stateManager = (IStateManager)stateManagerProperty;
+			var dependencies = typeof(RelationalQueryContextFactory).GetProperty("Dependencies", bindingFlags).GetValue(queryContextFactory);
+			var queryContextDependencies = typeof(DbContext).Assembly.GetType(typeof(QueryContextDependencies).FullName);
+			var stateManagerProperty = queryContextDependencies.GetProperty("StateManager", bindingFlags | BindingFlags.Public).GetValue(dependencies);
+			var stateManager = (IStateManager)stateManagerProperty;
 
-            return stateManager.Context;
-        }
-    }
+			return stateManager.Context;
+		}
+	}
 }

--- a/EFCore.BulkExtensions/IQueryableBatchExtensions.cs
+++ b/EFCore.BulkExtensions/IQueryableBatchExtensions.cs
@@ -12,15 +12,15 @@ namespace EFCore.BulkExtensions
         public static int BatchDelete<T>(this IQueryable<T> query) where T : class
         {
             DbContext context = BatchUtil.GetDbContext(query);
-            string sql = BatchUtil.GetSqlDelete(query);
-            return context.Database.ExecuteSqlCommand(sql);
+            (string sql, var sqlParameters) = BatchUtil.GetSqlDelete(query);
+            return context.Database.ExecuteSqlCommand(sql, sqlParameters);
         }
 
         public static int BatchUpdate<T>(this IQueryable<T> query, T updateValues, List<string> updateColumns = null) where T : class, new()
         {
             DbContext context = BatchUtil.GetDbContext(query);
             var (sql, sqlParameters) = BatchUtil.GetSqlUpdate(query, context, updateValues, updateColumns);
-            return context.Database.ExecuteSqlCommand(sql, sqlParameters.ToArray());
+            return context.Database.ExecuteSqlCommand(sql, sqlParameters);
         }
 
 
@@ -36,15 +36,15 @@ namespace EFCore.BulkExtensions
         public static async Task<int> BatchDeleteAsync<T>(this IQueryable<T> query) where T : class
         {
             DbContext context = BatchUtil.GetDbContext(query);
-            string sql = BatchUtil.GetSqlDelete(query);
-            return await context.Database.ExecuteSqlCommandAsync(sql);
+						(string sql, var sqlParameters) = BatchUtil.GetSqlDelete(query);
+            return await context.Database.ExecuteSqlCommandAsync(sql, sqlParameters);
         }
 
         public static async Task<int> BatchUpdateAsync<T>(this IQueryable<T> query, T updateValues, List<string> updateColumns = null) where T : class, new()
         {
             DbContext context = BatchUtil.GetDbContext(query);
             var (sql, sqlParameters) = BatchUtil.GetSqlUpdate(query, context, updateValues, updateColumns);
-            return await context.Database.ExecuteSqlCommandAsync(sql, sqlParameters.ToArray());
+            return await context.Database.ExecuteSqlCommandAsync(sql, sqlParameters);
         }
 
         public static async Task<int> BatchUpdateAsync<T>(this IQueryable<T> query, Expression<Func<T, T>> updateExpression) where T : class

--- a/EFCore.BulkExtensions/IQueryableExtensions.cs
+++ b/EFCore.BulkExtensions/IQueryableExtensions.cs
@@ -12,57 +12,57 @@ using Microsoft.Extensions.Logging;
 
 namespace EFCore.BulkExtensions
 {
-	public static class IQueryableExtensions
-	{
-		private static readonly TypeInfo QueryCompilerTypeInfo = typeof(QueryCompiler).GetTypeInfo();
+    public static class IQueryableExtensions
+    {
+        private static readonly TypeInfo QueryCompilerTypeInfo = typeof(QueryCompiler).GetTypeInfo();
 
-		private static readonly FieldInfo QueryCompilerField = typeof(EntityQueryProvider).GetTypeInfo().DeclaredFields.First(x => x.Name == "_queryCompiler");
+        private static readonly FieldInfo QueryCompilerField = typeof(EntityQueryProvider).GetTypeInfo().DeclaredFields.First(x => x.Name == "_queryCompiler");
 
-		private static readonly FieldInfo QueryModelGeneratorField = QueryCompilerTypeInfo.DeclaredFields.First(x => x.Name == "_queryModelGenerator");
+        private static readonly FieldInfo QueryModelGeneratorField = QueryCompilerTypeInfo.DeclaredFields.First(x => x.Name == "_queryModelGenerator");
 
-		private static readonly FieldInfo DataBaseField = QueryCompilerTypeInfo.DeclaredFields.Single(x => x.Name == "_database");
+        private static readonly FieldInfo DataBaseField = QueryCompilerTypeInfo.DeclaredFields.Single(x => x.Name == "_database");
 
-		private static readonly PropertyInfo DatabaseDependenciesField = typeof(Database).GetTypeInfo().DeclaredProperties.Single(x => x.Name == "Dependencies");
+        private static readonly PropertyInfo DatabaseDependenciesField = typeof(Database).GetTypeInfo().DeclaredProperties.Single(x => x.Name == "Dependencies");
 
-		internal static string ToSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
-		{
-			var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
-			var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
-			var queryModel = modelGenerator.ParseQuery(query.Expression);
-			var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
-			var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
-			var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
-			var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
+        internal static string ToSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
+        {
+            var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
+            var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
+            var queryModel = modelGenerator.ParseQuery(query.Expression);
+            var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
+            var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
+            var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
+            var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
 
-			modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
-			//modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
-			// CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
-			// cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+            modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
+            //modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
+            // CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+            // cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
 
-			string sql = modelVisitor.Queries.First().ToString();
-			return sql;
-		}
+            string sql = modelVisitor.Queries.First().ToString();
+            return sql;
+        }
 
-		internal static (string, IEnumerable<SqlParameter>) ToParametrizedSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
-		{
-			var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
-			var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
-			var parameterValues = new SimpleParameterValues();
-			var diagnosticsLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(new LoggerFactory(), null, new DiagnosticListener("Temp"));
-			var parameterExpression = modelGenerator.ExtractParameters(diagnosticsLogger, query.Expression, parameterValues);
-			var queryModel = modelGenerator.ParseQuery(parameterExpression);
-			var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
-			var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
-			var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
-			var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
+        internal static (string, IEnumerable<SqlParameter>) ToParametrizedSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
+        {
+            var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
+            var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
+            var parameterValues = new SimpleParameterValues();
+            var diagnosticsLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(new LoggerFactory(), null, new DiagnosticListener("Temp"));
+            var parameterExpression = modelGenerator.ExtractParameters(diagnosticsLogger, query.Expression, parameterValues);
+            var queryModel = modelGenerator.ParseQuery(parameterExpression);
+            var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
+            var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
+            var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
+            var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
 
-			modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
-			//modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
-			// CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
-			// cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+            modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
+            //modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
+            // CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+            // cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
 
-			string sql = modelVisitor.Queries.First().ToString();
-			return (sql, parameterValues.ParameterValues.Select(x => new SqlParameter(x.Key, x.Value)));
-		}
-	}
+            string sql = modelVisitor.Queries.First().ToString();
+            return (sql, parameterValues.ParameterValues.Select(x => new SqlParameter(x.Key, x.Value)));
+        }
+    }
 }

--- a/EFCore.BulkExtensions/IQueryableExtensions.cs
+++ b/EFCore.BulkExtensions/IQueryableExtensions.cs
@@ -1,40 +1,68 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace EFCore.BulkExtensions
 {
-    public static class IQueryableExtensions
-    {
-        private static readonly TypeInfo QueryCompilerTypeInfo = typeof(QueryCompiler).GetTypeInfo();
+	public static class IQueryableExtensions
+	{
+		private static readonly TypeInfo QueryCompilerTypeInfo = typeof(QueryCompiler).GetTypeInfo();
 
-        private static readonly FieldInfo QueryCompilerField = typeof(EntityQueryProvider).GetTypeInfo().DeclaredFields.First(x => x.Name == "_queryCompiler");
+		private static readonly FieldInfo QueryCompilerField = typeof(EntityQueryProvider).GetTypeInfo().DeclaredFields.First(x => x.Name == "_queryCompiler");
 
-        private static readonly FieldInfo QueryModelGeneratorField = QueryCompilerTypeInfo.DeclaredFields.First(x => x.Name == "_queryModelGenerator");
+		private static readonly FieldInfo QueryModelGeneratorField = QueryCompilerTypeInfo.DeclaredFields.First(x => x.Name == "_queryModelGenerator");
 
-        private static readonly FieldInfo DataBaseField = QueryCompilerTypeInfo.DeclaredFields.Single(x => x.Name == "_database");
+		private static readonly FieldInfo DataBaseField = QueryCompilerTypeInfo.DeclaredFields.Single(x => x.Name == "_database");
 
-        private static readonly PropertyInfo DatabaseDependenciesField = typeof(Database).GetTypeInfo().DeclaredProperties.Single(x => x.Name == "Dependencies");
+		private static readonly PropertyInfo DatabaseDependenciesField = typeof(Database).GetTypeInfo().DeclaredProperties.Single(x => x.Name == "Dependencies");
 
-        internal static string ToSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
-        {
-            var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
-            var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
-            var queryModel = modelGenerator.ParseQuery(query.Expression);
-            var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
-            var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
-            var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
-            var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
+		internal static string ToSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
+		{
+			var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
+			var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
+			var queryModel = modelGenerator.ParseQuery(query.Expression);
+			var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
+			var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
+			var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
+			var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
 
-            modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
-            //modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
-            // CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
-            // cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+			modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
+			//modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
+			// CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+			// cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
 
-            string sql = modelVisitor.Queries.First().ToString();
-            return sql;
-        }
-    }
+			string sql = modelVisitor.Queries.First().ToString();
+			return sql;
+		}
+
+		internal static (string, IEnumerable<SqlParameter>) ToParametrizedSql<TEntity>(this IQueryable<TEntity> query) where TEntity : class
+		{
+			var queryCompiler = (QueryCompiler)QueryCompilerField.GetValue(query.Provider);
+			var modelGenerator = (QueryModelGenerator)QueryModelGeneratorField.GetValue(queryCompiler);
+			var parameterValues = new SimpleParameterValues();
+			var diagnosticsLogger = new DiagnosticsLogger<DbLoggerCategory.Query>(new LoggerFactory(), null, new DiagnosticListener("Temp"));
+			var parameterExpression = modelGenerator.ExtractParameters(diagnosticsLogger, query.Expression, parameterValues);
+			var queryModel = modelGenerator.ParseQuery(parameterExpression);
+			var database = (IDatabase)DataBaseField.GetValue(queryCompiler);
+			var databaseDependencies = (DatabaseDependencies)DatabaseDependenciesField.GetValue(database);
+			var queryCompilationContext = databaseDependencies.QueryCompilationContextFactory.Create(false);
+			var modelVisitor = (RelationalQueryModelVisitor)queryCompilationContext.CreateQueryModelVisitor();
+
+			modelVisitor.CreateQueryExecutor<TEntity>(queryModel);
+			//modelVisitor.CreateAsyncQueryExecutor<TEntity>(queryModel);
+			// CreateAsync not used, throws: Message: System.ArgumentException : Expression of type 'System.Collections.Generic.IEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+			// cannot be used for return type 'System.Collections.Generic.IAsyncEnumerable`1[EFCore.BulkExtensions.Tests.Item]'
+
+			string sql = modelVisitor.Queries.First().ToString();
+			return (sql, parameterValues.ParameterValues.Select(x => new SqlParameter(x.Key, x.Value)));
+		}
+	}
 }

--- a/EFCore.BulkExtensions/SimpleParameterValues.cs
+++ b/EFCore.BulkExtensions/SimpleParameterValues.cs
@@ -6,32 +6,32 @@ using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace EFCore.BulkExtensions
 {
-	internal class SimpleParameterValues: IParameterValues
-	{
-		private readonly Dictionary<string, object> _parameterValues = new Dictionary<string, object>();
+    internal class SimpleParameterValues : IParameterValues
+    {
+        private readonly Dictionary<string, object> _parameterValues = new Dictionary<string, object>();
 
-		public SimpleParameterValues()
-		{
-			
-		}
-		public void AddParameter(string name, object value )
-		{
-			_parameterValues.Add(name, value);
-		}
+        public SimpleParameterValues()
+        {
 
-		public object RemoveParameter(string name)
-		{
-			_parameterValues.TryGetValue(name, out var val);
-			_parameterValues.Remove(name);
-			return val;
-		}
+        }
+        public void AddParameter(string name, object value)
+        {
+            _parameterValues.Add(name, value);
+        }
 
-		public void SetParameter(string name, object value)
-		{
-			_parameterValues[name] = value;
-		}
+        public object RemoveParameter(string name)
+        {
+            _parameterValues.TryGetValue(name, out var val);
+            _parameterValues.Remove(name);
+            return val;
+        }
 
-		public IReadOnlyDictionary<string, object> ParameterValues => new ReadOnlyDictionary<string, object>(_parameterValues);
-	
-	}
+        public void SetParameter(string name, object value)
+        {
+            _parameterValues[name] = value;
+        }
+
+        public IReadOnlyDictionary<string, object> ParameterValues => new ReadOnlyDictionary<string, object>(_parameterValues);
+
+    }
 }

--- a/EFCore.BulkExtensions/SimpleParameterValues.cs
+++ b/EFCore.BulkExtensions/SimpleParameterValues.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace EFCore.BulkExtensions
+{
+	internal class SimpleParameterValues: IParameterValues
+	{
+		private readonly Dictionary<string, object> _parameterValues = new Dictionary<string, object>();
+
+		public SimpleParameterValues()
+		{
+			
+		}
+		public void AddParameter(string name, object value )
+		{
+			_parameterValues.Add(name, value);
+		}
+
+		public object RemoveParameter(string name)
+		{
+			_parameterValues.TryGetValue(name, out var val);
+			_parameterValues.Remove(name);
+			return val;
+		}
+
+		public void SetParameter(string name, object value)
+		{
+			_parameterValues[name] = value;
+		}
+
+		public IReadOnlyDictionary<string, object> ParameterValues => new ReadOnlyDictionary<string, object>(_parameterValues);
+	
+	}
+}


### PR DESCRIPTION
Batch operations: Inner query parameters are passed in the clear

When the original query used for the Batch operation contains parameters, they are passed in the clear (as values instead of query parameters) to the generated SQL query.
Example:
var now = DateTimeOffset.UtcNow;
var query = context.Items.Where(x => x.Id <= maxBatchId);
await query.BatchUpdateAsync(new Item() { LastSeenOn = now });

Expected query:
UPDATE [item] SET [LastSeenOn] = @LastSeenOn FROM [Items] AS [item] WHERE [x].[Id] <= @__maxBatchId_0

Actual query:
UPDATE [item] SET [LastSeenOn] = @LastSeenOn FROM [Items] AS [item] WHERE [x].[Id] <= CAST(1000 AS bigint)

Created an alternative to IQueryable.ToSql() - IQueryable.ToParametrizedSql() that builds the query using parameters instead of direct values. 
The SqlParameter list for the original query is returned as part of a Tuple together with the string Sql query. 
The batch operations use this list to populate their parameter lists before adding their own parameters.

Sorry for the mass whitespace changes - I realized too late that my Visual Studio reformatted the files.