### PR TITLE
BatchDelete fails with Contains

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -17,6 +17,7 @@ namespace EFCore.BulkExtensions.Tests
             RunInsert();
             RunBatchUpdate();
             RunBatchDelete();
+            RunContainsBatchDelete();
 
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
@@ -60,6 +61,15 @@ namespace EFCore.BulkExtensions.Tests
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
                 context.Items.Where(a => a.ItemId > 500).BatchDelete();
+            }
+        }
+
+        private void RunContainsBatchDelete()
+        {
+            var guidsToDelete = new List<Guid> { Guid.NewGuid() };
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();
             }
         }
 

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -86,6 +86,8 @@ namespace EFCore.BulkExtensions.Tests
         public DateTime TimeUpdated { get; set; }
 
         public ICollection<ItemHistory> ItemHistories { get; set; }
+
+        public Guid GuidId { get; set; }
     }
 
     // ItemHistory is used to test bulk Ops to multiple tables(Item and ItemHistory), to test Guid as PK and to test other Schema(his)


### PR DESCRIPTION
Hi. I really like this lib. Today I updated to the latest version and it seems to me there is a problem.
I need to perform a delete with an Contains check in the WHERE clause: 

`context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();`

This worked perfectly in Version 2.4.7 and started to fail in 2.4.8.
It seems to me that `query.ToParametrizedSql()` actually generates a wrong SQL statement:

![image](https://user-images.githubusercontent.com/168058/60981344-6e8ff380-a336-11e9-97e9-60360d2f048a.png)

I prepared a test to reproduce it but have no idea how to fix this. Do you have an idea?