### PR TITLE
BatchUpdate Fixes

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -29,6 +29,8 @@ namespace EFCore.BulkExtensions.Tests
                 Assert.Equal(500, lastItem.ItemId);
                 Assert.Equal("Updated", lastItem.Description);
                 Assert.Equal(1.5m, lastItem.Price);
+                Assert.StartsWith("name ", lastItem.Name);
+                Assert.EndsWith(" Concatenated", lastItem.Name);
             }
         }
 
@@ -60,7 +62,8 @@ namespace EFCore.BulkExtensions.Tests
                 query.BatchUpdate(new Item { Description = "Updated", Price = 1.5m }/*, updateColumns*/);
 
                 var incrementStep = 100;
-                query.BatchUpdate(a => new Item { Quantity = a.Quantity + incrementStep }); // example of BatchUpdate Increment/Decrement value in variable
+                var suffix = " Concatenated";
+                query.BatchUpdate(a => new Item { Name = a.Name + suffix, Quantity = a.Quantity + incrementStep }); // example of BatchUpdate Increment/Decrement value in variable
                 //query.BatchUpdate(a => new Item { Quantity = a.Quantity + 100 }); // example direct value without variable
             }
         }

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -28,6 +28,7 @@ namespace EFCore.BulkExtensions.Tests
                 var lastItem = context.Items.LastOrDefaultAsync().Result;
                 Assert.Equal(500, lastItem.ItemId);
                 Assert.Equal("Updated", lastItem.Description);
+                Assert.Null(lastItem.Price);
                 Assert.StartsWith("name ", lastItem.Name);
                 Assert.EndsWith(" Concatenated", lastItem.Name);
             }
@@ -82,9 +83,9 @@ namespace EFCore.BulkExtensions.Tests
 
                 decimal price = 0;
                 var query = context.Items.Where(a => a.ItemId <= 500 && a.Price >= price);
-                await query.BatchUpdateAsync(new Item { Description = "Updated", Price = 1.5m }/*, updateColumns*/);
+                await query.BatchUpdateAsync(new Item { Description = "Updated" }/*, updateColumns*/);
 
-                await query.BatchUpdateAsync(a => new Item { Name = a.Name + " Concatenated", Quantity = a.Quantity + 100 }); // example of BatchUpdate value Increment/Decrement
+                await query.BatchUpdateAsync(a => new Item { Name = a.Name + " Concatenated", Quantity = a.Quantity + 100, Price = null }); // example of BatchUpdate value Increment/Decrement
             }
         }
 

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -28,7 +28,8 @@ namespace EFCore.BulkExtensions.Tests
                 var lastItem = context.Items.LastOrDefaultAsync().Result;
                 Assert.Equal(500, lastItem.ItemId);
                 Assert.Equal("Updated", lastItem.Description);
-                Assert.Equal(1.5m, lastItem.Price);
+                Assert.StartsWith("name ", lastItem.Name);
+                Assert.EndsWith(" Concatenated", lastItem.Name);
             }
         }
 
@@ -83,7 +84,7 @@ namespace EFCore.BulkExtensions.Tests
                 var query = context.Items.Where(a => a.ItemId <= 500 && a.Price >= price);
                 await query.BatchUpdateAsync(new Item { Description = "Updated", Price = 1.5m }/*, updateColumns*/);
 
-                await query.BatchUpdateAsync(a => new Item { Quantity = a.Quantity + 100 }); // example of BatchUpdate value Increment/Decrement
+                await query.BatchUpdateAsync(a => new Item { Name = a.Name + " Concatenated", Quantity = a.Quantity + 100 }); // example of BatchUpdate value Increment/Decrement
             }
         }
 

--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -226,7 +226,7 @@ namespace EFCore.BulkExtensions
             else if (expression is ConstantExpression constantExpression)
             {
                 var parmName = $"param_{sqlParameters.Count}";
-                sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value));
+                sqlParameters.Add(new SqlParameter(parmName, constantExpression.Value ?? DBNull.Value));
                 sqlColumns.Append($" @{parmName}");
             }
             else if (expression is UnaryExpression unaryExpression)
@@ -279,7 +279,7 @@ namespace EFCore.BulkExtensions
             {
                 var value = Expression.Lambda(expression).Compile().DynamicInvoke();
                 var parmName = $"param_{sqlParameters.Count}";
-                sqlParameters.Add(new SqlParameter(parmName, value));
+                sqlParameters.Add(new SqlParameter(parmName, value ?? DBNull.Value));
                 sqlColumns.Append($" @{parmName}");
             }
         }

--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -69,7 +69,8 @@ namespace EFCore.BulkExtensions
             var sqlColumns = new StringBuilder();
             var sqlParameters = new List<object>(innerParameters);
             var columnNameValueDict = TableInfo.CreateInstance(GetDbContext(query), new List<T>(), OperationType.Read, new BulkConfig()).PropertyColumnNamesDict;
-            CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, ref sqlColumns, ref sqlParameters);
+            var dbType = GetDatabaseType(context);
+            CreateUpdateBody(columnNameValueDict, tableAlias, expression.Body, dbType, ref sqlColumns, ref sqlParameters);
 
             sqlParameters = ReloadSqlParameters(context, sqlParameters); // Sqlite requires SqliteParameters
             sqlColumns = (GetDatabaseType(context) == DbServer.SqlServer) ? sqlColumns : sqlColumns.Replace($"[{tableAlias}].", "");
@@ -193,7 +194,7 @@ namespace EFCore.BulkExtensions
         /// <param name="expression"></param>
         /// <param name="sqlColumns"></param>
         /// <param name="sqlParameters"></param>
-        public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, ref StringBuilder sqlColumns, ref List<object> sqlParameters)
+        public static void CreateUpdateBody(Dictionary<string, string> columnNameValueDict, string tableAlias, Expression expression, DbServer dbType, ref StringBuilder sqlColumns, ref List<object> sqlParameters)
         {
             if (expression is MemberInitExpression memberInitExpression)
             {
@@ -208,7 +209,7 @@ namespace EFCore.BulkExtensions
 
                         sqlColumns.Append(" =");
 
-                        CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, ref sqlColumns, ref sqlParameters);
+                        CreateUpdateBody(columnNameValueDict, tableAlias, assignment.Expression, dbType, ref sqlColumns, ref sqlParameters);
 
                         if (memberInitExpression.Bindings.IndexOf(item) < (memberInitExpression.Bindings.Count - 1))
                             sqlColumns.Append(" ,");
@@ -233,23 +234,23 @@ namespace EFCore.BulkExtensions
                 switch (unaryExpression.NodeType)
                 {
                     case ExpressionType.Convert:
-                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, dbType, ref sqlColumns, ref sqlParameters);
                         break;
                     case ExpressionType.Not:
                         sqlColumns.Append(" ~");//this way only for SQL Server 
-                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, ref sqlColumns, ref sqlParameters);
+                        CreateUpdateBody(columnNameValueDict, tableAlias, unaryExpression.Operand, dbType, ref sqlColumns, ref sqlParameters);
                         break;
                     default: break;
                 }
             }
             else if (expression is BinaryExpression binaryExpression)
             {
-                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, ref sqlColumns, ref sqlParameters);
+                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Left, dbType, ref sqlColumns, ref sqlParameters);
 
                 switch (binaryExpression.NodeType)
                 {
                     case ExpressionType.Add:
-                        sqlColumns.Append(" +");
+                        sqlColumns.Append(dbType == DbServer.Sqlite && IsStringConcat(binaryExpression) ? " ||" : " +");
                         break;
                     case ExpressionType.Divide:
                         sqlColumns.Append(" /");
@@ -272,7 +273,7 @@ namespace EFCore.BulkExtensions
                     default: break;
                 }
 
-                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, ref sqlColumns, ref sqlParameters);
+                CreateUpdateBody(columnNameValueDict, tableAlias, binaryExpression.Right, dbType, ref sqlColumns, ref sqlParameters);
             }
             else
             {
@@ -300,6 +301,19 @@ namespace EFCore.BulkExtensions
         public static DbServer GetDatabaseType(DbContext context)
         {
             return context.Database.ProviderName.EndsWith(DbServer.Sqlite.ToString()) ? DbServer.Sqlite : DbServer.SqlServer;
+        }
+
+        internal static bool IsStringConcat(BinaryExpression binaryExpression) {
+            var methodProperty = binaryExpression.GetType().GetProperty("Method");
+            if (methodProperty == null) {
+                return false;
+            }
+            var method = methodProperty.GetValue(binaryExpression) as MethodInfo;
+            if (method == null) {
+                return false;
+            }
+            return method.DeclaringType == typeof(string) && method.Name == nameof(string.Concat);
+
         }
     }
 }


### PR DESCRIPTION
- Add Sqlite string concat support (Sqlite concats strings using the double pipe `||` operator)
- Null values were not working when using `BatchUpdate` with the `updateExpression`.  `SqlParameters` are now set using `DBNull.Value`.