### PR TITLE
Fixed NuGet dependencies for .NET Standard

### DIFF
--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -22,6 +22,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />
+    <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When EFCore.BulkExtensions package from version 2.6.0 up - is to be installed in library targeting .NET Standard - it fails to install complaining about 3 libraries being downgraded. I've added them as dependencies and tested that package installation succeeds now.