### PR TITLE
BatchDelete fails with Contains and empty list

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -22,6 +22,8 @@ namespace EFCore.BulkExtensions.Tests
             RunBatchUpdate();
             RunBatchDelete();
             RunContainsBatchDelete();
+            RunContainsBatchDelete2();
+            RunContainsBatchDelete3_WithEmptyList();
 
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
@@ -41,13 +43,13 @@ namespace EFCore.BulkExtensions.Tests
                 context.Items.BatchDelete();
 
                 if (databaseType == DbServer.SqlServer)
-            {
-                context.Database.ExecuteSqlCommand("DBCC CHECKIDENT('[dbo].[Item]', RESEED, 0);");
-            }
+                {
+                    context.Database.ExecuteSqlCommand("DBCC CHECKIDENT('[dbo].[Item]', RESEED, 0);");
+                }
                 if (databaseType == DbServer.Sqlite)
                 {
                     context.Database.ExecuteSqlCommand("DELETE FROM sqlite_sequence WHERE name = 'Item';");
-        }
+                }
             }
         }
 
@@ -64,11 +66,11 @@ namespace EFCore.BulkExtensions.Tests
                 var incrementStep = 100;
                 var suffix = " Concatenated";
                 query.BatchUpdate(a => new Item { Name = a.Name + suffix, Quantity = a.Quantity + incrementStep }); // example of BatchUpdate Increment/Decrement value in variable
-                //query.BatchUpdate(a => new Item { Quantity = a.Quantity + 100 }); // example direct value without variable
+                                                                                                                    //query.BatchUpdate(a => new Item { Quantity = a.Quantity + 100 }); // example direct value without variable
             }
         }
 
-        private void RunContainsBatchDelete()
+        private void RunContainsBatchDelete2()
         {
             var guidsToDelete = new List<Guid> { Guid.NewGuid() };
             using (var context = new TestContext(ContextUtil.GetOptions()))
@@ -77,9 +79,9 @@ namespace EFCore.BulkExtensions.Tests
             }
         }
 
-        private void RunContainsBatchDelete()
+        private void RunContainsBatchDelete3_WithEmptyList()
         {
-            var guidsToDelete = new List<Guid> { Guid.NewGuid() };
+            var guidsToDelete = new List<Guid> { };
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
                 context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();
@@ -115,7 +117,7 @@ namespace EFCore.BulkExtensions.Tests
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
                 context.Items.Where(a => a.ItemId > 500).BatchDelete();
-    }
+            }
         }
 
         private void RunContainsBatchDelete()

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -77,6 +77,15 @@ namespace EFCore.BulkExtensions.Tests
             }
         }
 
+        private void RunContainsBatchDelete()
+        {
+            var guidsToDelete = new List<Guid> { Guid.NewGuid() };
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();
+            }
+        }
+
         private void RunInsert()
         {
             using (var context = new TestContext(ContextUtil.GetOptions()))

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -41,13 +41,13 @@ namespace EFCore.BulkExtensions.Tests
                 context.Items.BatchDelete();
 
                 if (databaseType == DbServer.SqlServer)
-                {
-                    context.Database.ExecuteSqlCommand("DBCC CHECKIDENT('[dbo].[Item]', RESEED, 0);");
-                }
+            {
+                context.Database.ExecuteSqlCommand("DBCC CHECKIDENT('[dbo].[Item]', RESEED, 0);");
+            }
                 if (databaseType == DbServer.Sqlite)
                 {
                     context.Database.ExecuteSqlCommand("DELETE FROM sqlite_sequence WHERE name = 'Item';");
-                }
+        }
             }
         }
 
@@ -65,6 +65,15 @@ namespace EFCore.BulkExtensions.Tests
                 var suffix = " Concatenated";
                 query.BatchUpdate(a => new Item { Name = a.Name + suffix, Quantity = a.Quantity + incrementStep }); // example of BatchUpdate Increment/Decrement value in variable
                 //query.BatchUpdate(a => new Item { Quantity = a.Quantity + 100 }); // example direct value without variable
+            }
+        }
+
+        private void RunContainsBatchDelete()
+        {
+            var guidsToDelete = new List<Guid> { Guid.NewGuid() };
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();
             }
         }
 
@@ -97,7 +106,7 @@ namespace EFCore.BulkExtensions.Tests
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
                 context.Items.Where(a => a.ItemId > 500).BatchDelete();
-            }
+    }
         }
 
         private void RunContainsBatchDelete()

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -40,7 +40,7 @@ namespace EFCore.BulkExtensions.Tests
 
             if (Database.IsSqlServer())
             {
-                modelBuilder.Entity<Document>().Property(p => p.ContentLength).HasComputedColumnSql($"(CONVERT([int], len([{nameof(Document.Content)}])))");
+            modelBuilder.Entity<Document>().Property(p => p.ContentLength).HasComputedColumnSql($"(CONVERT([int], len([{nameof(Document.Content)}])))");
             }
             else if (Database.IsSqlite())
             {
@@ -65,9 +65,9 @@ namespace EFCore.BulkExtensions.Tests
 
             if (DbServer == DbServer.SqlServer)
             {
-                var connectionString = $"Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
+            var connectionString = $"Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
                 optionsBuilder.UseSqlServer(connectionString); // Can NOT Test with UseInMemoryDb (Exception: Relational-specific methods can only be used when the context is using a relational)
-            }
+        }
             else if (DbServer == DbServer.Sqlite)
             {
                 string connectionString = $"Data Source={databaseName}.db";
@@ -76,7 +76,7 @@ namespace EFCore.BulkExtensions.Tests
                 // ALTERNATIVELY:
                 //string connectionString = (new SqliteConnectionStringBuilder { DataSource = $"{databaseName}Lite.db" }).ToString();
                 //optionsBuilder.UseSqlite(new SqliteConnection(connectionString));
-            }
+    }
             else
             {
                 throw new NotSupportedException($"Database {DbServer} is not supported. Only SQL Server and SQLite are Currently supported.");
@@ -115,6 +115,8 @@ namespace EFCore.BulkExtensions.Tests
         public DateTime TimeUpdated { get; set; }
 
         public ICollection<ItemHistory> ItemHistories { get; set; }
+
+        public Guid GuidId { get; set; }
     }
 
     // ItemHistory is used to test bulk Ops to multiple tables(Item and ItemHistory), to test Guid as PK and to test other Schema(his)


### PR DESCRIPTION
Hi. I really like this lib. Yesterday I updated to the latest version (2.6.3) and it seems to me there is a problem. I need to perform a delete with a Contains check in the WHERE clause:

`context.Items.Where(a => guidsToDelete.Contains(a.GuidId)).BatchDelete();`

This worked perfectly in Version 2.4.7 and started to fail in 2.4.8 (https://github.com/borisdj/EFCore.BulkExtensions/pull/203) which is why I didn't update until yesterday.

It seemed to work but in case of `guidsToDelete` being an empty list it fails again:

> System.ArgumentException : No mapping exists from object type System.Collections.Generic.List`1[[System.Guid, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]] to a known managed provider native type.

I don't know how to fix this, so this PR offers just a test to reproduce. Do you have an idea?