### PR TITLE
[238] add support to TOP statement for SQL server in EFCore 2.2

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -20,17 +20,21 @@ namespace EFCore.BulkExtensions.Tests
             RunBatchDeleteAll(databaseType);
             RunInsert();
             RunBatchUpdate();
+            int deletedEntities = RunTopBatchDelete();
             RunBatchDelete();
             RunContainsBatchDelete();
 
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
+                var firstItem = context.Items.FirstOrDefault();
                 var lastItem = context.Items.LastOrDefault();
+                Assert.Equal(1, deletedEntities);
                 Assert.Equal(500, lastItem.ItemId);
                 Assert.Equal("Updated", lastItem.Description);
                 Assert.Equal(1.5m, lastItem.Price);
                 Assert.StartsWith("name ", lastItem.Name);
                 Assert.EndsWith(" Concatenated", lastItem.Name);
+                Assert.EndsWith(" TOP(1)", firstItem.Name);
             }
         }
 
@@ -65,6 +69,8 @@ namespace EFCore.BulkExtensions.Tests
                 var suffix = " Concatenated";
                 query.BatchUpdate(a => new Item { Name = a.Name + suffix, Quantity = a.Quantity + incrementStep }); // example of BatchUpdate Increment/Decrement value in variable
                 //query.BatchUpdate(a => new Item { Quantity = a.Quantity + 100 }); // example direct value without variable
+
+                query.Take(1).BatchUpdate(a => new Item { Name = a.Name + " TOP(1)", Quantity = a.Quantity + incrementStep }); // example of BatchUpdate with TOP(1)
             }
         }
 
@@ -89,6 +95,14 @@ namespace EFCore.BulkExtensions.Tests
 
                 context.Items.AddRange(entities); // does not guarantee insert order for SqlServer
                 context.SaveChanges();
+            }
+        }
+
+        private int RunTopBatchDelete()
+        {
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                return context.Items.Where(a => a.ItemId > 500).Take(1).BatchDelete();
             }
         }
 

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -21,16 +21,20 @@ namespace EFCore.BulkExtensions.Tests
             await RunBatchDeleteAllAsync(databaseType);
             await RunInsertAsync();
             await RunBatchUpdateAsync();
+            int deletedEntities = await RunTopBatchDeleteAsync();
             await RunBatchDeleteAsync();
 
             using (var context = new TestContext(ContextUtil.GetOptions()))
             {
-                var lastItem = context.Items.LastOrDefaultAsync().Result;
+                var firstItem = await context.Items.FirstOrDefaultAsync();
+                var lastItem = await context.Items.LastOrDefaultAsync();
+                Assert.Equal(1, deletedEntities);
                 Assert.Equal(500, lastItem.ItemId);
                 Assert.Equal("Updated", lastItem.Description);
                 Assert.Null(lastItem.Price);
                 Assert.StartsWith("name ", lastItem.Name);
                 Assert.EndsWith(" Concatenated", lastItem.Name);
+                Assert.EndsWith(" TOP(1)", firstItem.Name);
             }
         }
 
@@ -86,6 +90,17 @@ namespace EFCore.BulkExtensions.Tests
                 await query.BatchUpdateAsync(new Item { Description = "Updated" }/*, updateColumns*/);
 
                 await query.BatchUpdateAsync(a => new Item { Name = a.Name + " Concatenated", Quantity = a.Quantity + 100, Price = null }); // example of BatchUpdate value Increment/Decrement
+
+                query = context.Items.Where(a => a.ItemId <= 500 && a.Price == null);
+                await query.Take(1).BatchUpdateAsync(a => new Item { Name = a.Name + " TOP(1)", Quantity = a.Quantity + 100 }); // example of BatchUpdate with TOP(1)
+            }
+        }
+
+        private async Task<int> RunTopBatchDeleteAsync()
+        {
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                return await context.Items.Where(a => a.ItemId > 500).Take(1).BatchDeleteAsync();
             }
         }
 


### PR DESCRIPTION
Support "TOP(xx)" statement for SQL Server in batch delete and batch update in EFCore 2.2.
This is useful for scenarios in which we have for example a recurring job to delete just a few records each time it runs.

Really like this extension, great job 👍 