### PR TITLE
Support long for identity type in sqlite

### DIFF
--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -304,13 +304,26 @@ namespace EFCore.BulkExtensions
                     {
                         command.CommandText = SqlQueryBuilderSqlite.SelectLastInsertRowId();
                         long lastRowIdScalar = (long)command.ExecuteScalar();
-                        int lastRowId = (int)lastRowIdScalar;
+                        var identityPropertyInteger = false;
                         var accessor = TypeAccessor.Create(typeof(T), true);
                         string identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
+                        if (accessor.GetMembers().FirstOrDefault(x => x.Name == identityPropertyName)?.Type == typeof(int))
+                        {
+                            identityPropertyInteger = true;
+                        }
                         for (int i = entities.Count -1; i >= 0; i--)
                         {
-                            accessor[entities[i], identityPropertyName] = lastRowId;
-                            lastRowId--;
+                            if (identityPropertyInteger)
+                            {
+                                accessor[entities[i], identityPropertyName] = (int) lastRowIdScalar;
+
+                            }
+                            else
+                            {
+                                accessor[entities[i], identityPropertyName] = lastRowIdScalar;
+                            }
+
+                            lastRowIdScalar--;
                         }
                     }
                 }


### PR DESCRIPTION
There is an error thrown right now when you have an identity column that is a long type because the identity is explicitly cast to an int. I changed it to only cast to an int if the identity is an int.