### PR TITLE
Fix dotnet pack error with Sqlite package

### DIFF
--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Problem:
When you install Microsoft.EntityFrameworkCore.Sqlite 3.1.0 you can see dlls without modify date. It cause to "The DateTimeOffset specified cannot be converted into a Zip file timestamp" when you try to pack project.

Solution:
Update lib version

related problem
https://github.com/NuGetPackageExplorer/NuGetPackageExplorer/issues/269
https://github.com/OrchardCMS/OrchardCore/issues/4477
https://github.com/NuGet/Home/issues/7001