### PR TITLE
Update Microsoft.Data.SqlClient reference to version 1.1.1

### DIFF
--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FastMember" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />


### PR DESCRIPTION
As described at https://github.com/dotnet/SqlClient/issues/262, version 1.1.0 of Microsoft.Data.SqlClient has a bug that can cause deadlocks in async calls, which is fixed in the 1.1.1 release.

refs #281.