### PR TITLE
Bulk-Operations should not close an open connection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+
+[*.cs]
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -288,15 +288,12 @@ namespace EFCore.BulkExtensions
         #region SqlCommands
         public void CheckHasIdentity(DbContext context)
         {
-            var sqlConnection = context.Database.GetDbConnection();
-            var currentTransaction = context.Database.CurrentTransaction;
+            context.Database.OpenConnection();
             try
             {
-                if (currentTransaction == null)
-                {
-                    if (sqlConnection.State != ConnectionState.Open)
-                        sqlConnection.Open();
-                }
+                var sqlConnection = context.Database.GetDbConnection();
+                var currentTransaction = context.Database.CurrentTransaction;
+
                 using (var command = sqlConnection.CreateCommand())
                 {
                     if (currentTransaction != null)
@@ -316,8 +313,7 @@ namespace EFCore.BulkExtensions
             }
             finally
             {
-                if (currentTransaction == null)
-                    sqlConnection.Close();
+                context.Database.CloseConnection();
             }
         }
 

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -323,15 +323,12 @@ namespace EFCore.BulkExtensions
 
         public async Task CheckHasIdentityAsync(DbContext context, CancellationToken cancellationToken)
         {
+            await context.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
             var sqlConnection = context.Database.GetDbConnection();
             var currentTransaction = context.Database.CurrentTransaction;
             try
             {
-                if (currentTransaction == null)
-                {
-                    if (sqlConnection.State != ConnectionState.Open)
-                        await sqlConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
-                }
                 using (var command = sqlConnection.CreateCommand())
                 {
                     if (currentTransaction != null)
@@ -351,10 +348,7 @@ namespace EFCore.BulkExtensions
             }
             finally
             {
-                if (currentTransaction == null)
-                {
-                    sqlConnection.Close();
-                }
+                await context.Database.CloseConnectionAsync().ConfigureAwait(false);
             }
         }
 
@@ -398,15 +392,13 @@ namespace EFCore.BulkExtensions
         public async Task<bool> CheckTableExistAsync(DbContext context, TableInfo tableInfo, CancellationToken cancellationToken)
         {
             bool tableExist = false;
-            var sqlConnection = context.Database.GetDbConnection();
-            var currentTransaction = context.Database.CurrentTransaction;
+            await context.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
             try
             {
-                if (currentTransaction == null)
-                {
-                    if (sqlConnection.State != ConnectionState.Open)
-                        await sqlConnection.OpenAsync(cancellationToken).ConfigureAwait(false); ;
-                }
+                var sqlConnection = context.Database.GetDbConnection();
+                var currentTransaction = context.Database.CurrentTransaction;
+
                 using (var command = sqlConnection.CreateCommand())
                 {
                     if (currentTransaction != null)
@@ -426,8 +418,7 @@ namespace EFCore.BulkExtensions
             }
             finally
             {
-                if (currentTransaction == null)
-                    sqlConnection.Close();
+                await context.Database.CloseConnectionAsync().ConfigureAwait(false);
             }
             return tableExist;
         }


### PR DESCRIPTION
PR for issue #253 

The issue still exists in the new version. I've provided tests and bugfixes for both the sync and async operations. There were multiple occurrences that closes the connection that was opened by "someone else" before but that may be not all of them.

Please backport the fixes to version 2.x if the solution is acceptable for you because a lot of companies are still using EF Core 2.x. Thx!

btw. there are/were 4 tests that are failing before my change.

PS: I've added an .editorconfig so the code style of the contributors are maching yours.