### PR TITLE
Extend the fix for #295 to SqlBulkOperation.MergeAsync

### DIFF
--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -476,13 +476,25 @@ namespace EFCore.BulkExtensions
                     {
                         command.CommandText = SqlQueryBuilderSqlite.SelectLastInsertRowId();
                         long lastRowIdScalar = (long)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-                        int lastRowId = (int)lastRowIdScalar;
+                        var identityPropertyInteger = false;
                         var accessor = TypeAccessor.Create(type, true);
                         string identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
+                        if (accessor.GetMembers().FirstOrDefault(x => x.Name == identityPropertyName)?.Type == typeof(int))
+                        {
+                            identityPropertyInteger = true;
+                        }
                         for (int i = entities.Count - 1; i >= 0; i--)
                         {
-                            accessor[entities[i], identityPropertyName] = lastRowId;
-                            lastRowId--;
+                            if (identityPropertyInteger)
+                            {
+                                accessor[entities[i], identityPropertyName] = (int)lastRowIdScalar;
+                            }
+                            else
+                            {
+                                accessor[entities[i], identityPropertyName] = lastRowIdScalar;
+                            }
+
+                            lastRowIdScalar--;
                         }
                     }
                 }


### PR DESCRIPTION
I was doing some tests with BulkInsertAsync using Sqlite and fell across what looks like #295, which I think might be because #296 only fixed the sync version of Merge.

This PR just applies the same change to MergeAsync. (which seems to fix my tests, though I don't know enough about how it works to say if this is the best approach)