### PR TITLE
#326 Set unique temp table name if needed

### DIFF
--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -22,6 +22,8 @@ namespace EFCore.BulkExtensions
 
         public bool UseTempDB { get; set; }
 
+        public TempDBSettings TempDBSettings { get; set; }
+
         public bool TrackingEntities { get; set; }
 
         public bool UseOnlyDataTable { get; set; }
@@ -53,5 +55,10 @@ namespace EFCore.BulkExtensions
         public int StatsNumberInserted { get; set; }
 
         public int StatsNumberUpdated { get; set; }
+    }
+
+    public class TempDBSettings
+    {
+        public bool UniqueTableName { get; set; } = true;
     }
 }

--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -42,9 +42,17 @@ namespace EFCore.BulkExtensions
             return q;
         }
 
-        public static string DropTable(string tableName)
+        public static string DropTable(string tableName, bool isTempTable)
         {
-            var q = $"IF OBJECT_ID('{tableName}', 'U') IS NOT NULL DROP TABLE {tableName}";
+            string q = null;
+            if (isTempTable)
+            {
+                q = $"IF OBJECT_ID ('tempdb..[#{tableName.Split('#')[1]}', 'U') IS NOT NULL DROP TABLE {tableName}";
+            }
+            else
+            {
+                q = $"IF OBJECT_ID ('{tableName}', 'U') IS NOT NULL DROP TABLE {tableName}";
+            }
             return q;
         }
 


### PR DESCRIPTION
Set unique temp table name if needed. In some cases, there is no need to create a unique table name for temp DB (reducing new execution plan creations) 