### PR TITLE
Provide helpful exception message when table contains no primary key

### DIFF
--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -122,6 +122,8 @@ namespace EFCore.BulkExtensions
 
             bool AreSpecifiedUpdateByProperties = BulkConfig.UpdateByProperties?.Count() > 0;
             var primaryKeys = entityType.FindPrimaryKey()?.Properties?.Select(a => a.Name)?.ToList();
+            if (primaryKeys == null)
+                throw new InvalidOperationException($"EntitySet for Type: { type.Name } must contain a Primary Key");
             HasSinglePrimaryKey = primaryKeys.Count == 1;
             PrimaryKeys = AreSpecifiedUpdateByProperties ? BulkConfig.UpdateByProperties : primaryKeys;
 

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -94,7 +94,9 @@ namespace EFCore.BulkExtensions
             TempTableSufix = "Temp" + Guid.NewGuid().ToString().Substring(0, 8); // 8 chars of Guid as tableNameSufix to avoid same name collision with other tables
 
             bool AreSpecifiedUpdateByProperties = BulkConfig.UpdateByProperties?.Count() > 0;
-            var primaryKeys = entityType.FindPrimaryKey().Properties.Select(a => a.Name).ToList();
+            var primaryKeys = entityType.FindPrimaryKey()?.Properties.Select(a => a.Name).ToList();
+            if (primaryKeys == null)
+                throw new InvalidOperationException($"EntitySet for Type: { type.Name } must contain a Primary Key");
             HasSinglePrimaryKey = primaryKeys.Count == 1;
             PrimaryKeys = AreSpecifiedUpdateByProperties ? BulkConfig.UpdateByProperties : primaryKeys;
 


### PR DESCRIPTION
Currently when an entity type with no Key is used it would throw a NullReferenceException. This change instead throws an InvalidOperationException with message "EntitySet for Type: { type.Name } must contain a Primary Key"