### PR TITLE
Update SqlBulkOperation.cs for SQLite

### DIFF
--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -820,13 +820,13 @@ namespace EFCore.BulkExtensions
                         }
 
                         if (subPropertiesLevel1 == null)
-                            value = DBNull.Value;
+                            value = null;
                         else
-                            value = subPropertiesLevel1.GetType().GetProperty(subProperties[1]).GetValue(subPropertiesLevel1) ?? DBNull.Value;
+                            value = subPropertiesLevel1.GetType().GetProperty(subProperties[1]).GetValue(subPropertiesLevel1);
                     }
                     else
                     {
-                        value = typeAccessor[entity, propertyColumn.Key] ?? DBNull.Value;
+                        value = typeAccessor[entity, propertyColumn.Key];
                     }
                 }
                 else // IsShadowProperty
@@ -836,10 +836,10 @@ namespace EFCore.BulkExtensions
 
                 if (tableInfo.ConvertibleProperties.ContainsKey(propertyColumn.Key))
                 {
-                    value = tableInfo.ConvertibleProperties[propertyColumn.Key].ConvertToProvider.Invoke(value) ?? DBNull.Value;
+                    value = tableInfo.ConvertibleProperties[propertyColumn.Key].ConvertToProvider.Invoke(value);
                 }
 
-                command.Parameters[$"@{propertyColumn.Value}"].Value = value;
+                command.Parameters[$"@{propertyColumn.Value}"].Value = value ?? DBNull.Value;
             }
         }
         #endregion

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -836,7 +836,7 @@ namespace EFCore.BulkExtensions
 
                 if (tableInfo.ConvertibleProperties.ContainsKey(propertyColumn.Key))
                 {
-                    value = tableInfo.ConvertibleProperties[propertyColumn.Key].ConvertToProvider.Invoke(value);
+                    value = tableInfo.ConvertibleProperties[propertyColumn.Key].ConvertToProvider.Invoke(value) ?? DBNull.Value;
                 }
 
                 command.Parameters[$"@{propertyColumn.Value}"].Value = value;


### PR DESCRIPTION
When using SQLite and a custom Converter that ouputs a null value, we must also convert it to DBNull.Value or it crashes.