### PR TITLE
Fix query generation with auto identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 obj
 .vs
 *.user
+.idea

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -344,7 +344,7 @@ namespace EFCore.BulkExtensions
                         long lastRowIdScalar = (long)command.ExecuteScalar();
                         var identityPropertyInteger = false;
                         var accessor = TypeAccessor.Create(type, true);
-                        string identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
+                        string identityPropertyName = tableInfo.IdentityColumnName;
                         if (accessor.GetMembers().FirstOrDefault(x => x.Name == identityPropertyName)?.Type == typeof(int))
                         {
                             identityPropertyInteger = true;

--- a/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
@@ -19,7 +19,8 @@ namespace EFCore.BulkExtensions
             bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
             if(operationType == OperationType.Insert && !keepIdentity)
             {
-                columnsList = columnsList.Where(a => a != tableInfo.IdentityColumnName).ToList();
+                var identityColumnName = tableInfo.PropertyColumnNamesDict[tableInfo.IdentityColumnName];
+                columnsList = columnsList.Where(a => a != identityColumnName).ToList();
             }
 
             var commaSeparatedColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsList);


### PR DESCRIPTION
Fix generation of the query when column name differ between model and database. (for exemple bounding_box_id in database and BoundingBoxId in the model)

This pull request is a proposal to fix the issue https://github.com/borisdj/EFCore.BulkExtensions/issues/349