### PR TITLE
Fix NullReferenceException on bulk operations on entities with no keys

### DIFF
--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -121,6 +121,7 @@ namespace EFCore.BulkExtensions
                     {
                         var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
+                        type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
                         var typeAccessor = TypeAccessor.Create(type, true);
                         int rowsCopied = 0;
                         foreach (var item in entities)
@@ -228,6 +229,7 @@ namespace EFCore.BulkExtensions
                     {
                         var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
+                        type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
                         var typeAccessor = TypeAccessor.Create(type, true);
                         int rowsCopied = 0;
 
@@ -342,6 +344,7 @@ namespace EFCore.BulkExtensions
                     {
                         var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
+                        type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
                         var typeAccessor = TypeAccessor.Create(type, true);
                         int rowsCopied = 0;
                         foreach (var item in entities)
@@ -483,6 +486,7 @@ namespace EFCore.BulkExtensions
                     {
                         var command = GetSqliteCommand(context, type, entities, tableInfo, connection, transaction);
 
+                        type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
                         var typeAccessor = TypeAccessor.Create(type, true);
                         int rowsCopied = 0;
 

--- a/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
@@ -17,7 +17,7 @@ namespace EFCore.BulkExtensions
             List<string> columnsList = tableInfo.PropertyColumnNamesDict.Values.ToList();
 
             bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
-            if(operationType == OperationType.Insert && !keepIdentity)
+            if(operationType == OperationType.Insert && !keepIdentity && tableInfo.HasIdentity)
             {
                 var identityColumnName = tableInfo.PropertyColumnNamesDict[tableInfo.IdentityColumnName];
                 columnsList = columnsList.Where(a => a != identityColumnName).ToList();

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -123,7 +123,7 @@ namespace EFCore.BulkExtensions
             bool AreSpecifiedUpdateByProperties = BulkConfig.UpdateByProperties?.Count() > 0;
             var primaryKeys = entityType.FindPrimaryKey()?.Properties?.Select(a => a.Name)?.ToList();
 
-            HasSinglePrimaryKey = primaryKeys.Count == 1;
+            HasSinglePrimaryKey = primaryKeys?.Count == 1;
             PrimaryKeys = AreSpecifiedUpdateByProperties ? BulkConfig.UpdateByProperties : primaryKeys;
 
             var allProperties = entityType.GetProperties().AsEnumerable();

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -132,9 +132,9 @@ namespace EFCore.BulkExtensions
             if (entityType.IsAbstract())
             {
                 var extendedAllProperties = allProperties.ToList();
-                foreach (var dervied in entityType.GetDirectlyDerivedTypes())
+                foreach (var derived in entityType.GetDirectlyDerivedTypes())
                 {
-                    extendedAllProperties.AddRange(dervied.GetProperties());
+                    extendedAllProperties.AddRange(derived.GetProperties());
                 }
 
                 allProperties = extendedAllProperties.Distinct();


### PR DESCRIPTION
@borisdj 

I tested this with an `InsertAsync` operation on an entity that was configured with `HasNoKey()`. It appears to work successfully. That said, I don't know the full context of this code, but it seems in line with the recent changes made in 121d2d5.