### PR TITLE
Properly pass cancellation tokens

### DIFF
--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -78,7 +78,7 @@ namespace EFCore.BulkExtensions
             }
             else if (operationType == OperationType.Truncate)
             {
-                return SqlBulkOperation.TruncateAsync(context, tableInfo);
+                return SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
             }
             else
             {
@@ -104,7 +104,7 @@ namespace EFCore.BulkExtensions
             }
             else if (operationType == OperationType.Truncate)
             {
-                return SqlBulkOperation.TruncateAsync(context, tableInfo);
+                return SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
             }
             else
             {

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -498,7 +498,7 @@ namespace EFCore.BulkExtensions
 
                 if (dropTempTableIfExists)
                 {
-                    await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB)).ConfigureAwait(false);
+                    await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB), cancellationToken).ConfigureAwait(false);
                 }
 
                 await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.CreateTableCopy(tableInfo.FullTableName, tableInfo.FullTempTableName, tableInfo), cancellationToken).ConfigureAwait(false);
@@ -756,7 +756,7 @@ namespace EFCore.BulkExtensions
 
             if (dropTempTableIfExists)
             {
-                await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB)).ConfigureAwait(false);
+                await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB), cancellationToken).ConfigureAwait(false);
             }
 
             string providerName = context.Database.ProviderName;

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -827,19 +827,19 @@ namespace EFCore.BulkExtensions
             }
         }
 
-        public static async Task TruncateAsync(DbContext context, TableInfo tableInfo)
+        public static async Task TruncateAsync(DbContext context, TableInfo tableInfo, CancellationToken cancellationToken)
         {
             string providerName = context.Database.ProviderName;
             // -- SQL Server --
             if (providerName.EndsWith(DbServer.SqlServer.ToString()))
             {
-                await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.TruncateTable(tableInfo.FullTableName));
+                await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.TruncateTable(tableInfo.FullTableName), cancellationToken);
 
             }
             // -- Sqlite --
             else if (providerName.EndsWith(DbServer.Sqlite.ToString()))
             {
-                context.Database.ExecuteSqlRaw(SqlQueryBuilder.DeleteTable(tableInfo.FullTableName));
+                await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DeleteTable(tableInfo.FullTableName), cancellationToken);
             }
             else
             {


### PR DESCRIPTION
* The method `EFCore.BulkExtensions.SqlBulkOperation.TruncateAsync` was missing a `CancellationToken`parameter. It has been added and forwarded to `ExecuteSqlRawAsync`.
* Both `MergeAsync` and `ReadAsync` take a `CancellationToken` parameter. This commit properly passes the cancellation token to the `ExecuteSqlRawAsync` method when dropping the temporary table.