### PR TITLE
Keep stack trace information when rethrowing exceptions

### DIFF
--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -85,7 +85,7 @@ namespace EFCore.BulkExtensions
                                         context.Database.ExecuteSqlRaw(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB));
                                     }
                                 }
-                                throw ex;
+                                throw;
                             }
                         }
                     }
@@ -110,7 +110,7 @@ namespace EFCore.BulkExtensions
                                         context.Database.ExecuteSqlRaw(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB));
                                     }
                                 }
-                                throw ex;
+                                throw;
                             }
                         }
                     }
@@ -206,7 +206,7 @@ namespace EFCore.BulkExtensions
                                         await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB), cancellationToken).ConfigureAwait(false);
                                     }
                                 }
-                                throw ex;
+                                throw;
                             }
                         }
                     }
@@ -231,7 +231,7 @@ namespace EFCore.BulkExtensions
                                         await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB), cancellationToken).ConfigureAwait(false);
                                     }
                                 }
-                                throw ex;
+                                throw;
                             }
                         }
                     }


### PR DESCRIPTION
Found by enabling code analysis by adding `<AnalysisLevel>latest</AnalysisLevel>` in the project file and using the .NET 5.0.101 SDK.

See also https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200