### PR TITLE
Disable unit test parallelization

### DIFF
--- a/EFCore.BulkExtensions.Tests/Properties/AssemblyInfo.cs
+++ b/EFCore.BulkExtensions.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
This PR adds an `AssemblyInfo` file, in which xUnit is instructed not to run any tests in parallel. This is because the tests don't work when run in parallel. This change decreases the number of failing tests from +/- 13 to 7. The remaining failing tests also fail when run on their own, so that they still fail is expected.