### PR TITLE
Fix bulk delete with output table and add deletions to statistics

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -168,7 +168,8 @@ namespace EFCore.BulkExtensions.Tests
                                     PreserveInsertOrder = true,
                                     SetOutputIdentity = true,
                                     BatchSize = 4000,
-                                    UseTempDB = true
+                                    UseTempDB = true,
+                                    CalculateStats = true
                                 },
                                 (a) => WriteProgress(a)
                             );

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -135,7 +135,7 @@ namespace EFCore.BulkExtensions.Tests
                     {
                         using (var transaction = await context.Database.BeginTransactionAsync())
                         {
-                            await context.BulkInsertAsync(entities, new BulkConfig { PreserveInsertOrder = true, SetOutputIdentity = true, BatchSize = 4000 });
+                            await context.BulkInsertAsync(entities, new BulkConfig { PreserveInsertOrder = true, SetOutputIdentity = true, BatchSize = 4000, CalculateStats = true });
 
                             foreach (var entity in entities)
                             {

--- a/EFCore.BulkExtensions.Tests/TestExample.sql
+++ b/EFCore.BulkExtensions.Tests/TestExample.sql
@@ -28,8 +28,15 @@ WHEN NOT MATCHED BY TARGET THEN INSERT ([Description], [Name], [Price], [Quantit
 VALUES (S.[Description], S.[Name], S.[Price], S.[Quantity], S.[TimeUpdated])
 WHEN MATCHED THEN UPDATE SET T.[Description] = S.[Description], T.[Name] = S.[Name], T.[Price] = S.[Price], T.[Quantity] = S.[Quantity], T.[TimeUpdated] = S.[TimeUpdated]
 --WHEN NOT MATCHED BY SOURCE THEN DELETE
+--OUTPUT COALESCE(INSERTED.[ItemId], DELETED.[ItemId]), COALESCE(INSERTED.[Description], DELETED.[Description]), COALESCE(INSERTED.[Name], DELETED.[Name]), COALESCE(INSERTED.[Price], DELETED.[Price]), COALESCE(INSERTED.[Quantity], DELETED.[Quantity]), COALESCE(INSERTED.[TimeUpdated], DELETED.[TimeUpdated])
 OUTPUT INSERTED.[ItemId], INSERTED.[Description], INSERTED.[Name], INSERTED.[Price], INSERTED.[Quantity], INSERTED.[TimeUpdated] -- All columns: INSERTED.*
 INTO [dbo].[ItemTemp1234Output];
+
+-- INSERT Item without corresponding value in ItemTemp1234, so it will be deleted when enabling DELETE in the previous query
+INSERT INTO [dbo].[Item]
+([Description], [Name], [Price], [Quantity], [TimeUpdated])
+VALUES
+('Desc4', 'SomeName4', 16.12, 39, '2017-01-01')
 
 -- Delete TempTable
 DROP TABLE [dbo].[ItemTemp1234];

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -51,5 +51,7 @@ namespace EFCore.BulkExtensions
         public int StatsNumberInserted { get; set; }
 
         public int StatsNumberUpdated { get; set; }
+
+        public int StatsNumberDeleted { get; set; }
     }
 }

--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -139,7 +139,16 @@ namespace EFCore.BulkExtensions
             }
             if (tableInfo.CreatedOutputTable)
             {
-                q += $" OUTPUT {GetCommaSeparatedColumns(outputColumnsNames, "INSERTED")}" + isUpdateStatsValue +
+                string commaSeparatedColumnsNames;
+                if (operationType == OperationType.InsertOrUpdateDelete || operationType == OperationType.Delete)
+                {
+                    commaSeparatedColumnsNames = string.Join(", ", outputColumnsNames.Select(x => $"COALESCE(INSERTED.[{x}], DELETED.[{x}])"));
+                }
+                else
+                {
+                    commaSeparatedColumnsNames = GetCommaSeparatedColumns(outputColumnsNames, "INSERTED");
+                }
+                q += $" OUTPUT {commaSeparatedColumnsNames}" + isUpdateStatsValue +
                      $" INTO {tableInfo.FullTempOutputTableName}";
             }
             q += ";";

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -495,6 +495,17 @@ namespace EFCore.BulkExtensions
             return (int)resultParameter.Value;
         }
 
+        protected int GetNumberDeleted(DbContext context)
+        {
+            var resultParameter = SqlClientHelper.CreateParameter(context.Database.GetDbConnection());
+            resultParameter.ParameterName = "@result";
+            resultParameter.DbType = DbType.Int32;
+            resultParameter.Direction = ParameterDirection.Output;
+            string sqlQueryCount = SqlQueryBuilder.SelectCountIsDeleteFromOutputTable(this);
+            context.Database.ExecuteSqlRaw($"SET @result = ({sqlQueryCount});", resultParameter);
+            return (int)resultParameter.Value;
+        }
+
         protected async Task<int> GetNumberUpdatedAsync(DbContext context, CancellationToken cancellationToken)
         {
             var resultParameters = new List<IDbDataParameter>();
@@ -504,6 +515,19 @@ namespace EFCore.BulkExtensions
             p.Direction = ParameterDirection.Output;
             resultParameters.Add(p);
             string sqlQueryCount = SqlQueryBuilder.SelectCountIsUpdateFromOutputTable(this);
+            await context.Database.ExecuteSqlRawAsync($"SET @result = ({sqlQueryCount});", resultParameters, cancellationToken).ConfigureAwait(false); // TODO cancellationToken if Not
+            return (int)resultParameters.FirstOrDefault().Value;
+        }
+
+        protected async Task<int> GetNumberDeletedAsync(DbContext context, CancellationToken cancellationToken)
+        {
+            var resultParameters = new List<IDbDataParameter>();
+            var p = SqlClientHelper.CreateParameter(context.Database.GetDbConnection());
+            p.ParameterName = "@result";
+            p.DbType = DbType.Int32;
+            p.Direction = ParameterDirection.Output;
+            resultParameters.Add(p);
+            string sqlQueryCount = SqlQueryBuilder.SelectCountIsDeleteFromOutputTable(this);
             await context.Database.ExecuteSqlRawAsync($"SET @result = ({sqlQueryCount});", resultParameters, cancellationToken).ConfigureAwait(false); // TODO cancellationToken if Not
             return (int)resultParameters.FirstOrDefault().Value;
         }
@@ -636,13 +660,13 @@ namespace EFCore.BulkExtensions
             }
             if (BulkConfig.CalculateStats)
             {
-                string sqlQueryCount = SqlQueryBuilder.SelectCountIsUpdateFromOutputTable(this);
-
                 int numberUpdated = GetNumberUpdated(context);
+                int numberDeleted = GetNumberDeleted(context);
                 BulkConfig.StatsInfo = new StatsInfo
                 {
                     StatsNumberUpdated = numberUpdated,
-                    StatsNumberInserted = entities.Count - numberUpdated
+                    StatsNumberDeleted = numberDeleted,
+                    StatsNumberInserted = entities.Count - numberUpdated - numberDeleted
                 };
             }
         }
@@ -671,10 +695,12 @@ namespace EFCore.BulkExtensions
             if (BulkConfig.CalculateStats)
             {
                 int numberUpdated = await GetNumberUpdatedAsync(context, cancellationToken).ConfigureAwait(false);
+                int numberDeleted = await GetNumberDeletedAsync(context, cancellationToken).ConfigureAwait(false);
                 BulkConfig.StatsInfo = new StatsInfo
                 {
                     StatsNumberUpdated = numberUpdated,
-                    StatsNumberInserted = entities.Count - numberUpdated
+                    StatsNumberDeleted = numberDeleted,
+                    StatsNumberInserted = entities.Count - numberUpdated - numberDeleted
                 };
             }
         }


### PR DESCRIPTION
This PR fixes a bug where the following methods fail if an output table is used (e.g. `CalculateStats` is `true`):
- BulkDelete
- BulkDeleteAsync
- BulkInsertOrUpdateOrDelete
- BulkInsertOrUpdateOrDeleteAsync

The bug is caused by the fact that the `MERGE` statement does not output anything through the `INSERTED` collection for deleted records. Instead, it outputs those records in the `DELETED` collection. Therefore, when using `INSERTED`, an error about not being able to insert a `NULL` value is thrown.

I fixed the bug by using the `COALESCE` operator, which is (at least) available in MS Sql Server, Sqlite, PostgreSQL and MySql. When a value in the `INSERTED` collection is `NULL`, it falls back to the corresponding value in the `DELETED` collection.

Additionally, this PR fixes the `StatsInfo` so deletions are now counted separately in a `StatsNumberDeleted` property. Previously, deletions were counted under `StatsNumberInserted`.

Furthermore, this PR:
- Adds tests for InsertOrUpdateOrDelete(Async)
- Enables `CalculateStats` for all bulk operation tests that did not have it yet, so the fix is tested for those operations as well:
  - BulkInsert
  - BulkInsertAsync
  - BulkUpdate
  - BulkDelete
  - BulkDeleteAsync
- Validates the `StatsInfo` results in all relevant unit tests
- Adds a query and query component to `TestExample.sql` to make it incorporate the fix as well