### PR TITLE
Support for ValueConverters defined using Pre-defined conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 .vs
 *.user
 .idea
+/EFCore.BulkExtensions.Tests/testsettings.local.json

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -27,4 +27,13 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="testsettings.local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="testsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
@@ -29,7 +29,7 @@ namespace EFCore.BulkExtensions.Tests
         {
             var builder = new DbContextOptionsBuilder<TestContext>();
             var databaseName = nameof(EFCoreBulkTest);
-            var connectionString = $"Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true";
+            var connectionString = ContextUtil.GetSqlServerConnectionString(databaseName);
             var connection = new SqlConnection(connectionString) as DbConnection;
             connection = new MyConnection(connection);
             builder.UseSqlServer(connection);

--- a/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
@@ -1,0 +1,51 @@
+﻿using EFCore.BulkExtensions.SqlAdapters;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests.ShadowProperties
+{
+    public class ShadowPropertyTests : IDisposable
+    {
+        [Theory]
+        [InlineData(DbServer.SqlServer)]
+        [InlineData(DbServer.Sqlite)]
+        public void BulkInsertOrUpdate_EntityWithShadowProperties_SavesToDatabase(DbServer databaseType)
+        {
+            ContextUtil.DbServer = databaseType;
+
+            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>());
+
+            db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
+            {
+                EnableShadowProperties = true
+            });
+
+            var modelFromDb = db.SpModels.OrderByDescending(y => y.Id).First();
+            Assert.Equal((long)10, db.Entry(modelFromDb).Property(SpModel.SpLong).CurrentValue);
+            Assert.Null(db.Entry(modelFromDb).Property(SpModel.SpNullableLong).CurrentValue);
+
+            Assert.Equal(new DateTime(2021, 02, 14), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+        }
+
+        private IEnumerable<SpModel> GetTestData(DbContext db)
+        {
+            var one = new SpModel();
+            db.Entry(one).Property(SpModel.SpLong).CurrentValue = (long)10;
+            db.Entry(one).Property(SpModel.SpNullableLong).CurrentValue = null;
+            db.Entry(one).Property(SpModel.SpDateTime).CurrentValue = new DateTime(2021, 02, 14);
+
+            yield return one;
+        }
+
+        public void Dispose()
+        {
+            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>());
+            db.Database.EnsureDeleted();
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
@@ -18,7 +18,7 @@ namespace EFCore.BulkExtensions.Tests.ShadowProperties
         {
             ContextUtil.DbServer = databaseType;
 
-            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>());
+            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties"));
 
             db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
             {
@@ -44,7 +44,7 @@ namespace EFCore.BulkExtensions.Tests.ShadowProperties
 
         public void Dispose()
         {
-            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>());
+            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties"));
             db.Database.EnsureDeleted();
         }
     }

--- a/EFCore.BulkExtensions.Tests/ShadowProperties/SpDbContext.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/SpDbContext.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EFCore.BulkExtensions.Tests.ShadowProperties
+{
+    public class SpDbContext : DbContext
+    {
+        public SpDbContext([NotNull] DbContextOptions options) : base(options)
+        {
+            this.Database.EnsureCreated();
+        }
+
+        public DbSet<SpModel> SpModels { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<SpModel>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+                cfg.Property(y => y.Id).UseIdentityColumn();
+
+                // Define the shadow properties
+                cfg.Property<long>(SpModel.SpLong);
+                cfg.Property<long?>(SpModel.SpNullableLong);
+
+                cfg.Property<DateTime>(SpModel.SpDateTime);
+            });
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/ShadowProperties/SpModel.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/SpModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.ShadowProperties
+{
+    public class SpModel
+    {
+        public int Id { get; set; }
+
+        public const string SpLong = nameof(SpLong);
+        public const string SpNullableLong = nameof(SpNullableLong);
+        public const string SpDateTime = nameof(SpDateTime);
+    }
+}

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -80,14 +80,14 @@ namespace EFCore.BulkExtensions.Tests
         public static DbContextOptions GetOptions(IInterceptor dbInterceptor) => GetOptions(new[] { dbInterceptor });
         public static DbContextOptions GetOptions(IEnumerable<IInterceptor> dbInterceptors = null) => GetOptions<TestContext>(dbInterceptors);
 
-        public static DbContextOptions GetOptions<TDbContext>(IEnumerable<IInterceptor> dbInterceptors = null)
+        public static DbContextOptions GetOptions<TDbContext>(IEnumerable<IInterceptor> dbInterceptors = null, string databaseName = nameof(EFCoreBulkTest))
             where TDbContext: DbContext
         {
             var optionsBuilder = new DbContextOptionsBuilder<TDbContext>();
 
             if (DbServer == DbServer.SqlServer)
             {
-                var connectionString = GetSqlServerConnectionString();
+                var connectionString = GetSqlServerConnectionString(databaseName);
 
                 // ALTERNATIVELY (Using MSSQLLocalDB):
                 //var connectionString = $@"Data Source=(localdb)\MSSQLLocalDB;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=True";
@@ -96,7 +96,7 @@ namespace EFCore.BulkExtensions.Tests
             }
             else if (DbServer == DbServer.Sqlite)
             {
-                string connectionString = GetSqliteConnectionString();
+                string connectionString = GetSqliteConnectionString(databaseName);
                 optionsBuilder.UseSqlite(connectionString);
 
                 // ALTERNATIVELY:
@@ -125,15 +125,13 @@ namespace EFCore.BulkExtensions.Tests
             return configBuilder.Build();
         }
 
-        public static string GetSqlServerConnectionString()
+        public static string GetSqlServerConnectionString(string databaseName)
         {
-            var databaseName = nameof(EFCoreBulkTest);
             return GetConfiguration().GetConnectionString("SqlServer").Replace("{databaseName}", databaseName);
         }
 
-        public static string GetSqliteConnectionString()
+        public static string GetSqliteConnectionString(string databaseName)
         {
-            var databaseName = nameof(EFCoreBulkTest);
             return GetConfiguration().GetConnectionString("Sqlite").Replace("{databaseName}", databaseName);
         }
     }

--- a/EFCore.BulkExtensions.Tests/ValueConverters/ValueConverterTests.cs
+++ b/EFCore.BulkExtensions.Tests/ValueConverters/ValueConverterTests.cs
@@ -1,0 +1,54 @@
+﻿using EFCore.BulkExtensions.SqlAdapters;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests.ValueConverters
+{
+    public class ValueConverterTests: IDisposable
+    {
+        [Theory]
+        [InlineData(DbServer.SqlServer)]
+        [InlineData(DbServer.Sqlite)]
+        public void BulkInsertOrUpdate_EntityUsingBuiltInEnumToStringConverter_SavesToDatabase(DbServer databaseType)
+        {
+            ContextUtil.DbServer = databaseType;
+
+            using var db = new VcDbContext(ContextUtil.GetOptions<VcDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ValueConverters"));
+
+            db.BulkInsertOrUpdate(this.GetTestData(db).ToList());
+
+            var connection = db.Database.GetDbConnection();
+            connection.Open();
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT * FROM VcModels ORDER BY Id DESC";
+            cmd.CommandType = System.Data.CommandType.Text;
+
+            using var reader = cmd.ExecuteReader();
+            reader.Read();
+
+            var enumStr = reader.Field<string>("Enum");
+
+            Assert.Equal(VcEnum.Hello.ToString(), enumStr);
+        }
+
+        private IEnumerable<VcModel> GetTestData(DbContext db)
+        {
+            var one = new VcModel();
+            one.Enum = VcEnum.Hello;
+
+            yield return one;
+        }
+
+        public void Dispose()
+        {
+            using var db = new VcDbContext(ContextUtil.GetOptions<VcDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ValueConverters"));
+            db.Database.EnsureDeleted();
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/ValueConverters/VcDbContext.cs
+++ b/EFCore.BulkExtensions.Tests/ValueConverters/VcDbContext.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EFCore.BulkExtensions.Tests.ValueConverters
+{
+    public class VcDbContext : DbContext
+    {
+        public VcDbContext([NotNull] DbContextOptions options) : base(options)
+        {
+            this.Database.EnsureCreated();
+        }
+
+        public DbSet<VcModel> VcModels { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<VcModel>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+                cfg.Property(y => y.Id).UseIdentityColumn();
+
+                cfg.Property(y => y.Enum).HasColumnType("nvarchar(4000)").HasConversion<string>();
+
+            });
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/ValueConverters/VcModel.cs
+++ b/EFCore.BulkExtensions.Tests/ValueConverters/VcModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.ValueConverters
+{
+    public class VcModel
+    {
+        public int Id { get; set; }
+
+        public VcEnum Enum { get; set; }
+    }
+
+    public enum VcEnum
+    {
+        Why,
+        Hello,
+        There
+    }
+}

--- a/EFCore.BulkExtensions.Tests/testsettings.json
+++ b/EFCore.BulkExtensions.Tests/testsettings.json
@@ -1,0 +1,6 @@
+{
+  "ConnectionStrings": {
+    "SqlServer": "Server=localhost;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true;",
+    "Sqlite": "Data Source={databaseName}.db"
+  }
+}

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -35,6 +35,8 @@ namespace EFCore.BulkExtensions
 
         public List<string> UpdateByProperties { get; set; }
 
+        public bool EnableShadowProperties { get; set; } = false;
+
         // since Microsoft.Data.SqlClient.SqlBulkCopyOptions is a superset of 
         // System.Data.SqlClient.SqlBulkCopyOptions, allow user to always specify
         // Microsoft.Data.SqlClient and we will convert it to the desired type

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.12" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -219,10 +219,16 @@ namespace EFCore.BulkExtensions
             {
                 PropertyColumnNamesDict = properties.ToDictionary(a => a.Name, b => b.GetColumnName().Replace("]", "]]"));
                 ShadowProperties = new HashSet<string>(properties.Where(p => p.IsShadowProperty() && !p.IsForeignKey()).Select(p => p.GetColumnName()));
-                foreach (var property in properties.Where(p => p.GetValueConverter() != null))
+                foreach (var property in properties)
                 {
-                    string columnName = property.GetColumnName();
-                    ValueConverter converter = property.GetValueConverter();
+                    var converter = property.GetTypeMapping().Converter;
+
+                    if (converter is null)
+                    {
+                        continue;
+                    }
+
+                    var columnName = property.GetColumnName();
                     ConvertibleProperties.Add(columnName, converter);
                 }
 


### PR DESCRIPTION
Closes #438 

ValueConversion will now work correctly with pre-defined conversions.
```cs
protected override void OnModelCreating(ModelBuilder modelBuilder)
{
    modelBuilder
        .Entity<Rider>()
        .Property(e => e.Mount)
        .HasConversion<string>();
}
```