### PR TITLE
Fix the AmbiguousMatchException with EF core 5

### DIFF
--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -410,7 +410,7 @@ namespace EFCore.BulkExtensions
         }
 
         private static readonly MethodInfo DbContextSetMethodInfo = typeof(DbContext)
-            .GetMethod(nameof(DbContext.Set), BindingFlags.Public | BindingFlags.Instance);
+            .GetMethod(nameof(DbContext.Set), new Type[] {});
 
         public static readonly Regex TableAliasPattern = new Regex(@"(?:FROM|JOIN)\s+(\[\S+\]) AS (\[\S+\])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
Fixes the AmbiguousMatchException error that occurs with EF core 5 when doing bulk operations.
https://github.com/borisdj/EFCore.BulkExtensions/issues/466