### PR TITLE
Add option to exclude properties from the insert and/or update portions in BulkInsertOrUpdate method.

### DIFF
--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace EFCore.BulkExtensions.Tests
@@ -29,7 +30,42 @@ namespace EFCore.BulkExtensions.Tests
             string expected = "MERGE [dbo].[Item] WITH (HOLDLOCK) AS T USING [dbo].[ItemTemp1234] AS S " +
                               "ON T.[ItemId] = S.[ItemId] " +
                               "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name]) VALUES (S.[Name]) " +
-                              "WHEN MATCHED THEN UPDATE SET T.[Name] = S.[Name];";
+                              "WHEN MATCHED AND EXISTS (SELECT S.[Name] " +
+                              "EXCEPT SELECT T.[Name]) " +
+                              "THEN UPDATE SET T.[Name] = S.[Name];";
+
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public void MergeTableInsertOrUpdateWithCompareTest()
+        {
+            TableInfo tableInfo = GetTestTableWithCompareInfo();
+            tableInfo.IdentityColumnName = "ItemId";
+            string result = SqlQueryBuilder.MergeTable(tableInfo, OperationType.InsertOrUpdate);
+
+            string expected = "MERGE [dbo].[Item] WITH (HOLDLOCK) AS T USING [dbo].[ItemTemp1234] AS S " +
+                              "ON T.[ItemId] = S.[ItemId] " +
+                              "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [TimeUpdated]) VALUES (S.[Name], S.[TimeUpdated]) " +
+                              "WHEN MATCHED AND EXISTS (SELECT S.[Name] " +
+                              "EXCEPT SELECT T.[Name]) " +
+                              "THEN UPDATE SET T.[Name] = S.[Name], T.[TimeUpdated] = S.[TimeUpdated];";
+
+            Assert.Equal(result, expected);
+        }
+        [Fact]
+        public void MergeTableInsertOrUpdateNoUpdateTest()
+        {
+            TableInfo tableInfo = GetTestTableWithNoUpdateInfo();
+            tableInfo.IdentityColumnName = "ItemId";
+            string result = SqlQueryBuilder.MergeTable(tableInfo, OperationType.InsertOrUpdate);
+
+            string expected = "MERGE [dbo].[Item] WITH (HOLDLOCK) AS T USING [dbo].[ItemTemp1234] AS S " +
+                              "ON T.[ItemId] = S.[ItemId] " +
+                              "WHEN NOT MATCHED BY TARGET THEN INSERT ([Name], [TimeUpdated]) VALUES (S.[Name], S.[TimeUpdated]) " +
+                              "WHEN MATCHED AND EXISTS (SELECT S.[Name], S.[TimeUpdated] " +
+                              "EXCEPT SELECT T.[Name], T.[TimeUpdated]) " +
+                              "THEN UPDATE SET T.[Name] = S.[Name];";
 
             Assert.Equal(result, expected);
         }
@@ -43,7 +79,9 @@ namespace EFCore.BulkExtensions.Tests
 
             string expected = "MERGE [dbo].[Item] WITH (HOLDLOCK) AS T USING [dbo].[ItemTemp1234] AS S " +
                               "ON T.[ItemId] = S.[ItemId] " +
-                              "WHEN MATCHED THEN UPDATE SET T.[Name] = S.[Name];";
+                              "WHEN MATCHED AND EXISTS (SELECT S.[Name] " +
+                              "EXCEPT SELECT T.[Name]) " +
+                              "THEN UPDATE SET T.[Name] = S.[Name];";
 
             Assert.Equal(result, expected);
         }
@@ -52,7 +90,7 @@ namespace EFCore.BulkExtensions.Tests
         public void SelectJoinTableReadTest()
         {
             TableInfo tableInfo = GetTestTableInfo();
-            tableInfo.BulkConfig.UpdateByProperties = new List<string> { nameof(Item.Name) };
+            tableInfo.BulkConfig.UpdateByProperties = new List<string> {nameof(Item.Name)};
             string result = SqlQueryBuilder.SelectJoinTable(tableInfo);
 
             string expected = "SELECT S.[ItemId], S.[Name] FROM [dbo].[Item] AS S " +
@@ -80,15 +118,70 @@ namespace EFCore.BulkExtensions.Tests
             var tableInfo = new TableInfo()
             {
                 Schema = "dbo",
-                TableName = "Item",
-                PrimaryKeys = new List<string> { "ItemId" },
+                TableName = nameof(Item),
+                PrimaryKeys = new List<string> { nameof(Item.ItemId) },
                 TempTableSufix = "Temp1234",
                 BulkConfig = new BulkConfig()
             };
-            var nameText = "Name";
+            const string nameText = nameof(Item.Name);
 
             tableInfo.PropertyColumnNamesDict.Add(tableInfo.PrimaryKeys[0], tableInfo.PrimaryKeys[0]);
             tableInfo.PropertyColumnNamesDict.Add(nameText, nameText);
+            //compare on all columns (default)
+            tableInfo.PropertyColumnNamesCompareDict = tableInfo.PropertyColumnNamesDict;
+            //update all columns (default)
+            tableInfo.PropertyColumnNamesUpdateDict = tableInfo.PropertyColumnNamesDict;
+            return tableInfo;
+        }
+
+        private TableInfo GetTestTableWithCompareInfo()
+        {
+            var tableInfo = new TableInfo()
+            {
+                Schema = "dbo",
+                TableName = nameof(Item),
+                PrimaryKeys = new List<string> { nameof(Item.ItemId) },
+                TempTableSufix = "Temp1234",
+                BulkConfig = new BulkConfig()
+            };
+            const string nameText = nameof(Item.Name);
+            const string timeUpdatedText = nameof(Item.TimeUpdated);
+
+            tableInfo.PropertyColumnNamesDict.Add(tableInfo.PrimaryKeys[0], tableInfo.PrimaryKeys[0]);
+            tableInfo.PropertyColumnNamesDict.Add(nameText, nameText);
+            tableInfo.PropertyColumnNamesDict.Add(timeUpdatedText, timeUpdatedText);
+
+            //do not update if only the TimeUpdated changed
+            tableInfo.PropertyColumnNamesCompareDict =
+                tableInfo.PropertyColumnNamesDict.Where(p => p.Key != timeUpdatedText).ToDictionary(p => p.Key, p => p.Value);
+
+            //if an update id called, update all columns
+            tableInfo.PropertyColumnNamesUpdateDict = tableInfo.PropertyColumnNamesDict;
+            return tableInfo;
+        }
+        private TableInfo GetTestTableWithNoUpdateInfo()
+        {
+            var tableInfo = new TableInfo()
+            {
+                Schema = "dbo",
+                TableName = nameof(Item),
+                PrimaryKeys = new List<string> { nameof(Item.ItemId) },
+                TempTableSufix = "Temp1234",
+                BulkConfig = new BulkConfig()
+            };
+            const string nameText = nameof(Item.Name);
+            const string timeUpdatedText = nameof(Item.TimeUpdated);
+
+            tableInfo.PropertyColumnNamesDict.Add(tableInfo.PrimaryKeys[0], tableInfo.PrimaryKeys[0]);
+            tableInfo.PropertyColumnNamesDict.Add(nameText, nameText);
+            tableInfo.PropertyColumnNamesDict.Add(timeUpdatedText, timeUpdatedText);
+
+            //update a row if any of the values are updated
+            tableInfo.PropertyColumnNamesCompareDict = tableInfo.PropertyColumnNamesDict;
+
+            //the TimeUpdated can be inserted but not updated.
+            tableInfo.PropertyColumnNamesUpdateDict =
+                tableInfo.PropertyColumnNamesDict.Where(p => p.Key != timeUpdatedText).ToDictionary(p => p.Key, p => p.Value);
 
             return tableInfo;
         }

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -30,8 +30,12 @@ namespace EFCore.BulkExtensions
         public StatsInfo StatsInfo { get; set; }
 
         public List<string> PropertiesToInclude { get; set; }
+        public List<string> PropertiesToIncludeOnCompare { get; set; }
+        public List<string> PropertiesToIncludeOnUpdate { get; set; }
 
         public List<string> PropertiesToExclude { get; set; }
+        public List<string> PropertiesToExcludeOnCompare { get; set; }
+        public List<string> PropertiesToExcludeOnUpdate { get; set; }
 
         public List<string> UpdateByProperties { get; set; }
 

--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -115,8 +115,12 @@ namespace EFCore.BulkExtensions
             bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
             List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
             List<string> columnsNames = tableInfo.PropertyColumnNamesDict.Values.ToList();
+            List<string> columnsNamesOnCompare = tableInfo.PropertyColumnNamesCompareDict.Values.ToList();
+            List<string> columnsNamesOnUpdate = tableInfo.PropertyColumnNamesUpdateDict.Values.ToList();
             List<string> outputColumnsNames = tableInfo.OutputPropertyColumnNamesDict.Values.ToList();
             List<string> nonIdentityColumnsNames = columnsNames.Where(a => !a.Equals(tableInfo.IdentityColumnName, StringComparison.OrdinalIgnoreCase)).ToList();
+            List<string> compareColumnNames = columnsNamesOnCompare.Where(a => !a.Equals(tableInfo.IdentityColumnName, StringComparison.OrdinalIgnoreCase)).ToList();
+            List<string> updateColumnNames = columnsNamesOnUpdate.Where(a => !a.Equals(tableInfo.IdentityColumnName, StringComparison.OrdinalIgnoreCase)).ToList();
             List<string> insertColumnsNames = (tableInfo.HasIdentity && !keepIdentity) ? nonIdentityColumnsNames : columnsNames;
 
             string isUpdateStatsValue = (tableInfo.BulkConfig.CalculateStats) ? ",(CASE $action WHEN 'UPDATE' THEN 1 Else 0 END),(CASE $action WHEN 'DELETE' THEN 1 Else 0 END)" : "";
@@ -135,10 +139,15 @@ namespace EFCore.BulkExtensions
                 q += $" WHEN NOT MATCHED BY TARGET THEN INSERT ({GetCommaSeparatedColumns(insertColumnsNames)})" +
                      $" VALUES ({GetCommaSeparatedColumns(insertColumnsNames, "S")})";
             }
-            if ((operationType == OperationType.Update || operationType == OperationType.InsertOrUpdate || operationType == OperationType.InsertOrUpdateDelete) & nonIdentityColumnsNames.Count() > 0)
+
+            if ((operationType == OperationType.Update || operationType == OperationType.InsertOrUpdate ||
+                 operationType == OperationType.InsertOrUpdateDelete) & nonIdentityColumnsNames.Count > 0)
             {
-                q += $" WHEN MATCHED THEN UPDATE SET {GetCommaSeparatedColumns(nonIdentityColumnsNames, "T", "S")}";
+                q += $" WHEN MATCHED AND EXISTS (SELECT {GetCommaSeparatedColumns(compareColumnNames, "S")}" +
+                     $" EXCEPT SELECT {GetCommaSeparatedColumns(compareColumnNames, "T")})" +
+                     $" THEN UPDATE SET {GetCommaSeparatedColumns(updateColumnNames, "T", "S")}";
             }
+
             if (operationType == OperationType.InsertOrUpdateDelete)
             {
                 q += $" WHEN NOT MATCHED BY SOURCE THEN DELETE";

--- a/README.md
+++ b/README.md
@@ -85,11 +85,15 @@ More info in the [Example](https://github.com/borisdj/EFCore.BulkExtensions#read
 ## BulkConfig arguments
 
 **BulkInsert_/OrUpdate/OrDelete** methods can have optional argument **BulkConfig** with properties (bool, int, object, List<string>):<br>
-{ *PreserveInsertOrder, SetOutputIdentity, BatchSize, NotifyAfter, BulkCopyTimeout, EnableStreaming, UseTempDB, TrackingEntities, WithHoldlock, CalculateStats, StatsInfo, PropertiesToInclude, PropertiesToExclude, UpdateByProperties, SqlBulkCopyOptions }*<br>
+{ *PreserveInsertOrder, SetOutputIdentity, BatchSize, NotifyAfter, BulkCopyTimeout, EnableStreaming, UseTempDB, TrackingEntities, WithHoldlock, CalculateStats, StatsInfo, PropertiesToInclude, PropertiesToIncludeOnCompare, PropertiesToExclude, PropertiesToExcludeOnCompare, UpdateByProperties, SqlBulkCopyOptions }*<br>
 Default behaviour is <br>
-{ *PreserveInsertOrder*: false, *SetOutputIdentity*: false, *BatchSize*: 2000, *NotifyAfter*: null, *BulkCopyTimeout*: null,<br> *EnableStreaming*: false, *UseTempDB*: false, *TrackingEntities*: false, *WithHoldlock*: true,<br> *CalculateStats*: false, *StatsInfo*: null, *PropertiesToInclude*: null, *PropertiesToExclude*: null, *UpdateByProperties*: null, *SqlBulkCopyOptions*: Default }<br><br>
+{ *PreserveInsertOrder*: false, *SetOutputIdentity*: false, *BatchSize*: 2000, *NotifyAfter*: null, *BulkCopyTimeout*: null,<br> *EnableStreaming*: false, *UseTempDB*: false, *TrackingEntities*: false, *WithHoldlock*: true,<br> *CalculateStats*: false, *StatsInfo*: null, *PropertiesToInclude*: null, *PropertiesToIncludeOnCompare* : null, *PropertiesToExclude*: null, *PropertiesToExcludeOnCompare*: null, *UpdateByProperties*: null, *SqlBulkCopyOptions*: Default }<br><br>
 If we want to change defaults, BulkConfig should be added explicitly with one or more bool properties set to true, and/or int props like **BatchSize** to different number.<br> Config also has DelegateFunc for setting *Underlying-Connection/Transaction*, e.g. in UnderlyingTest.<br>
 When doing update we can chose to exclude one or more properties by adding their names into **PropertiesToExclude**, or if we need to update less then half column then **PropertiesToInclude** can be used. Setting both Lists are not allowed.<br><br>
+When using the **BulkInsert_/OrUpdate** methods, you may also specify the **PropertiesToIncludeOnCompare** and **PropertiesToExcludeOnCompare** properties. By adding a column name to the *PropertiesToExcludeOnCompare*, will allow it to be inserted and updated but will not update the row if any of the other columns in that row did not change. For example, if you are importing bulk data and want to keep an internal *CreateDate* or *UpdateDate*, you add those columns to the *PropertiesToExcludeOnCompare*.<br>
+Another option that may be used in the same scenario are the **PropertiesToIncludeOnUpdate** and **PropertiesToExcludeOnUpdate** properties. These properties will allow you to specify insert-only columns such as *CreateDate* and *CreatedBy*.
+<br><br>
+
 Additionaly there is **UpdateByProperties** for specifying custom properties, by which we want update to be done.<br>
 Using UpdateByProperties while also having Identity column requires that Id property be [Excluded](https://github.com/borisdj/EFCore.BulkExtensions/issues/131).<br>
 If **NotifyAfter** is not set it will have same value as _BatchSize_ while **BulkCopyTimeout** when not set has SqlBulkCopy default which is 30 seconds and if set to 0 it indicates no limit.<br><br>


### PR DESCRIPTION
Add option to exclude properties from the insert and/or update portions in BulkInsertOrUpdate method.

Let's say we have CreationDate/CreationBy properties - it should be inserted but never updated. We also have UpdateDate/UpdateBy properties - It should update when the row is updated but not because those values were updated. The four new properties **PropertiesToIncludeOnCompare**, **PropertiesToExcludeOnCompare**, **PropertiesToIncludeOnUpdate**, and **PropertiesToExcludeOnUpdate** allow for those columns to be specified. An added benefit of these new features is that even if they are not explicitly implimented by the user, *MERGE* performance is greatly improved. One of the slowest operations on a database is writing. The *EXISTS / EXCEPT* clause on the *MERGE* command will now only update rows that have changes instead of all records that have a match in the temp table.