### PR TITLE
Add ability to insert, update or merge the entity object graph using BulkConfig.IncludeGraph = true

### DIFF
--- a/EFCore.BulkExtensions.Tests/IncludeGraph/GraphDbContext.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/GraphDbContext.cs
@@ -31,15 +31,15 @@ namespace EFCore.BulkExtensions.Tests.ShadowProperties
                 cfg.HasKey(y => y.Id);
 
                 cfg.HasMany(y => y.WorkOrderSpares).WithOne(y => y.WorkOrder);
-                cfg.HasOne(y => y.Asset).WithMany();
+                cfg.HasOne(y => y.Asset).WithMany().IsRequired();
             });
 
             modelBuilder.Entity<WorkOrderSpare>(cfg =>
             {
                 cfg.HasKey(y => y.Id);
 
-                cfg.HasOne(y => y.WorkOrder).WithMany(y => y.WorkOrderSpares);
-                cfg.HasOne(y => y.Spare);
+                cfg.HasOne(y => y.WorkOrder).WithMany(y => y.WorkOrderSpares).IsRequired();
+                cfg.HasOne(y => y.Spare).WithMany().IsRequired();
             });
 
             modelBuilder.Entity<Spare>(cfg =>

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/GraphDbContext.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/GraphDbContext.cs
@@ -1,0 +1,52 @@
+﻿using EFCore.BulkExtensions.Tests.IncludeGraph.Model;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EFCore.BulkExtensions.Tests.ShadowProperties
+{
+    public class GraphDbContext : DbContext
+    {
+        public GraphDbContext([NotNull] DbContextOptions options) : base(options)
+        {
+            this.Database.EnsureCreated();
+        }
+
+        public DbSet<WorkOrder> WorkOrders { get; set; }
+        public DbSet<WorkOrderSpare> WorkOrderSpares { get; set; }
+        public DbSet<Asset> Assets { get; set; }
+        public DbSet<Spare> Spares { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Asset>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+            });
+
+            modelBuilder.Entity<WorkOrder>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+
+                cfg.HasMany(y => y.WorkOrderSpares).WithOne(y => y.WorkOrder);
+                cfg.HasOne(y => y.Asset).WithMany();
+            });
+
+            modelBuilder.Entity<WorkOrderSpare>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+
+                cfg.HasOne(y => y.WorkOrder).WithMany(y => y.WorkOrderSpares);
+                cfg.HasOne(y => y.Spare);
+            });
+
+            modelBuilder.Entity<Spare>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+            });
+
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
@@ -82,14 +82,14 @@ namespace EFCore.BulkExtensions.Tests.IncludeGraph
         [Theory]
         [InlineData(DbServer.SqlServer)]
         //[InlineData(DbServer.Sqlite)]
-        public void BulkInsertOrUpdate_EntityWithNestedObjectGraph_SavesGraphToDatabase(DbServer databaseType)
+        public async Task BulkInsertOrUpdate_EntityWithNestedObjectGraph_SavesGraphToDatabase(DbServer databaseType)
         {
             ContextUtil.DbServer = databaseType;
 
             using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
 
             var testData = this.GetTestData(db).ToList();
-            db.BulkInsertOrUpdate(testData, new BulkConfig
+            await db.BulkInsertOrUpdateAsync(testData, new BulkConfig
             {
                 IncludeGraph = true
             });

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
@@ -1,0 +1,78 @@
+﻿using EFCore.BulkExtensions.SqlAdapters;
+using EFCore.BulkExtensions.Tests.IncludeGraph.Model;
+using EFCore.BulkExtensions.Tests.ShadowProperties;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph
+{
+    public class IncludeGraphTests : IDisposable
+    {
+        [Theory]
+        [InlineData(DbServer.SqlServer)]
+        //[InlineData(DbServer.Sqlite)]
+        public void BulkInsertOrUpdate_EntityWithNestedObjectGraph_SavesGraphToDatabase(DbServer databaseType)
+        {
+            ContextUtil.DbServer = databaseType;
+
+            using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
+
+            db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
+            {
+                IncludeGraph = true,
+                EnableShadowProperties = true
+            });
+
+            Assert.True(db.WorkOrderSpares.Any());
+        }
+
+        private IEnumerable<WorkOrder> GetTestData(DbContext db)
+        {
+            var one = new WorkOrder
+            {
+                Description = "Fix belt",
+                Asset = new Asset
+                {
+                    Description = "MANU-1",
+                    Location = "WAREHOUSE-1"
+                },
+                WorkOrderSpares =
+                {
+                    new WorkOrderSpare
+                    {
+                        Description = "Bolt 5mm x5",
+                        Quantity = 5,
+                        Spare = new Spare
+                        {
+                            PartNumber = "MZD 5mm",
+                            Barcode = "12345"
+                        }
+                    },
+                    new WorkOrderSpare
+                    {
+                        Description = "Bolt 10mm x5",
+                        Quantity = 5,
+                        Spare = new Spare
+                        {
+                            PartNumber = "MZD 10mm",
+                            Barcode = "222655"
+                        }
+                    }
+                }
+            };
+
+            yield return one;
+        }
+
+        public void Dispose()
+        {
+            using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
+            db.Database.EnsureDeleted();
+        }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
@@ -13,35 +13,15 @@ namespace EFCore.BulkExtensions.Tests.IncludeGraph
 {
     public class IncludeGraphTests : IDisposable
     {
-        [Theory]
-        [InlineData(DbServer.SqlServer)]
-        //[InlineData(DbServer.Sqlite)]
-        public void BulkInsertOrUpdate_EntityWithNestedObjectGraph_SavesGraphToDatabase(DbServer databaseType)
+        private static WorkOrder WorkOrder1 = new WorkOrder
         {
-            ContextUtil.DbServer = databaseType;
-
-            using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
-
-            db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
+            Description = "Fix belt",
+            Asset = new Asset
             {
-                IncludeGraph = true,
-                EnableShadowProperties = true
-            });
-
-            Assert.True(db.WorkOrderSpares.Any());
-        }
-
-        private IEnumerable<WorkOrder> GetTestData(DbContext db)
-        {
-            var one = new WorkOrder
-            {
-                Description = "Fix belt",
-                Asset = new Asset
-                {
-                    Description = "MANU-1",
-                    Location = "WAREHOUSE-1"
-                },
-                WorkOrderSpares =
+                Description = "MANU-1",
+                Location = "WAREHOUSE-1"
+            },
+            WorkOrderSpares =
                 {
                     new WorkOrderSpare
                     {
@@ -64,9 +44,64 @@ namespace EFCore.BulkExtensions.Tests.IncludeGraph
                         }
                     }
                 }
-            };
+        };
 
-            yield return one;
+        private static WorkOrder WorkOrder2 = new WorkOrder
+        {
+            Description = "Fix toilets",
+            Asset = new Asset
+            {
+                Description = "FLUSHMASTER-1",
+                Location = "GYM-BLOCK-3"
+            },
+            WorkOrderSpares =
+            {
+                new WorkOrderSpare
+                {
+                    Description = "Plunger",
+                    Quantity = 2,
+                    Spare = new Spare
+                    {
+                        PartNumber = "Poo'o'magic 531",
+                        Barcode = "544532bbc"
+                    }
+                },
+                new WorkOrderSpare
+                {
+                    Description = "Crepepele",
+                    Quantity = 1,
+                    Spare = new Spare
+                    {
+                        PartNumber = "MZD f",
+                        Barcode = "222655"
+                    }
+                }
+            }
+        };
+
+        [Theory]
+        [InlineData(DbServer.SqlServer)]
+        [InlineData(DbServer.Sqlite)]
+        public void BulkInsertOrUpdate_EntityWithNestedObjectGraph_SavesGraphToDatabase(DbServer databaseType)
+        {
+            ContextUtil.DbServer = databaseType;
+
+            using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
+
+            db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
+            {
+                IncludeGraph = true,
+                EnableShadowProperties = true
+            });
+
+            Assert.True(db.WorkOrderSpares.Any());
+        }
+
+        private IEnumerable<WorkOrder> GetTestData(DbContext db)
+        {
+            yield return WorkOrder1;
+            yield return WorkOrder2;
+
         }
 
         public void Dispose()

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/Model/Asset.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/Model/Asset.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph.Model
+{
+    public class Asset
+    {
+        public int Id { get; set; }
+        public string Description { get; set; }
+        public string Location { get; set; }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/Model/Spare.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/Model/Spare.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph.Model
+{
+    public class Spare
+    {
+        public int Id { get; set; }
+
+        public string PartNumber { get; set; }
+        public string Barcode { get; set; }
+    }
+}

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/Model/WorkOrder.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/Model/WorkOrder.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph.Model
+{
+    public class WorkOrder
+    {
+        public int Id { get; set; }
+        public string Description { get; set; }
+
+        public Asset Asset { get; set; }
+        public ICollection<WorkOrderSpare> WorkOrderSpares { get; set; } = new HashSet<WorkOrderSpare>();
+    }
+}

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/Model/WorkOrderSpare.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/Model/WorkOrderSpare.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph.Model
+{
+    public class WorkOrderSpare
+    {
+        public int Id { get; set; }
+        public string Description { get; set; }
+        public decimal Quantity { get; set; }
+
+        public WorkOrder WorkOrder { get; set; }
+        public Spare Spare { get; set; }
+    }
+}

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -40,6 +40,7 @@ namespace EFCore.BulkExtensions
         public List<string> UpdateByProperties { get; set; }
 
         public bool EnableShadowProperties { get; set; } = false;
+        public bool IncludeGraph { get; set; } = false;
 
         public int SRID { get; set; } = 4326; // Spatial Reference Identifier // https://docs.microsoft.com/en-us/sql/relational-databases/spatial/spatial-reference-identifiers-srids
 

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EFCore.BulkExtensions
 {
-    internal static class DbContextBulkTransaction
+    internal static partial class DbContextBulkTransaction
     {
         public static void Execute<T>(DbContext context, IList<T> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress) where T : class
         {
@@ -17,23 +19,30 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                TableInfo tableInfo = TableInfo.CreateInstance(context, entities, operationType, bulkConfig);
-
-                if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                if (bulkConfig.IncludeGraph)
                 {
-                    SqlBulkOperation.Insert(context, entities, tableInfo, progress);
-                }
-                else if (operationType == OperationType.Read)
-                {
-                    SqlBulkOperation.Read(context, entities, tableInfo, progress);
-                }
-                else if (operationType == OperationType.Truncate)
-                {
-                    SqlBulkOperation.Truncate(context, tableInfo);
+                    DbContextBulkTransactionGraphUtil.ExecuteWithGraph(context, entities, operationType, bulkConfig, progress);
                 }
                 else
                 {
-                    SqlBulkOperation.Merge(context, entities, tableInfo, operationType, progress);
+                    TableInfo tableInfo = TableInfo.CreateInstance(context, entities, operationType, bulkConfig);
+
+                    if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                    {
+                        SqlBulkOperation.Insert(context, entities, tableInfo, progress);
+                    }
+                    else if (operationType == OperationType.Read)
+                    {
+                        SqlBulkOperation.Read(context, entities, tableInfo, progress);
+                    }
+                    else if (operationType == OperationType.Truncate)
+                    {
+                        SqlBulkOperation.Truncate(context, tableInfo);
+                    }
+                    else
+                    {
+                        SqlBulkOperation.Merge(context, entities, tableInfo, operationType, progress);
+                    }
                 }
             }
         }
@@ -47,23 +56,30 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
-
-                if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                if (bulkConfig.IncludeGraph)
                 {
-                    SqlBulkOperation.Insert(context, type, entities, tableInfo, progress);
-                }
-                else if (operationType == OperationType.Read)
-                {
-                    SqlBulkOperation.Read(context, type, entities, tableInfo, progress);
-                }
-                else if (operationType == OperationType.Truncate)
-                {
-                    SqlBulkOperation.Truncate(context, tableInfo);
+                    DbContextBulkTransactionGraphUtil.ExecuteWithGraph(context, entities, operationType, bulkConfig, progress);
                 }
                 else
                 {
-                    SqlBulkOperation.Merge(context, type, entities, tableInfo, operationType, progress);
+                    TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
+
+                    if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                    {
+                        SqlBulkOperation.Insert(context, type, entities, tableInfo, progress);
+                    }
+                    else if (operationType == OperationType.Read)
+                    {
+                        SqlBulkOperation.Read(context, type, entities, tableInfo, progress);
+                    }
+                    else if (operationType == OperationType.Truncate)
+                    {
+                        SqlBulkOperation.Truncate(context, tableInfo);
+                    }
+                    else
+                    {
+                        SqlBulkOperation.Merge(context, type, entities, tableInfo, operationType, progress);
+                    }
                 }
             }
         }
@@ -77,23 +93,30 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                TableInfo tableInfo = TableInfo.CreateInstance(context, entities, operationType, bulkConfig);
-
-                if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                if (bulkConfig.IncludeGraph)
                 {
-                    await SqlBulkOperation.InsertAsync(context, entities, tableInfo, progress, cancellationToken);
-                }
-                else if (operationType == OperationType.Read)
-                {
-                    await SqlBulkOperation.ReadAsync(context, entities, tableInfo, progress, cancellationToken);
-                }
-                else if (operationType == OperationType.Truncate)
-                {
-                    await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
+                    await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken);
                 }
                 else
                 {
-                    await SqlBulkOperation.MergeAsync(context, entities, tableInfo, operationType, progress, cancellationToken);
+                    TableInfo tableInfo = TableInfo.CreateInstance(context, entities, operationType, bulkConfig);
+
+                    if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                    {
+                        await SqlBulkOperation.InsertAsync(context, entities, tableInfo, progress, cancellationToken);
+                    }
+                    else if (operationType == OperationType.Read)
+                    {
+                        await SqlBulkOperation.ReadAsync(context, entities, tableInfo, progress, cancellationToken);
+                    }
+                    else if (operationType == OperationType.Truncate)
+                    {
+                        await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
+                    }
+                    else
+                    {
+                        await SqlBulkOperation.MergeAsync(context, entities, tableInfo, operationType, progress, cancellationToken);
+                    }
                 }
             }
         }
@@ -107,23 +130,30 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
-
-                if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                if (bulkConfig.IncludeGraph)
                 {
-                    await SqlBulkOperation.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken);
-                }
-                else if (operationType == OperationType.Read)
-                {
-                    await SqlBulkOperation.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken);
-                }
-                else if (operationType == OperationType.Truncate)
-                {
-                    await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
+                    await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken);
                 }
                 else
                 {
-                    await SqlBulkOperation.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken);
+                    TableInfo tableInfo = TableInfo.CreateInstance(context, type, entities, operationType, bulkConfig);
+
+                    if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
+                    {
+                        await SqlBulkOperation.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken);
+                    }
+                    else if (operationType == OperationType.Read)
+                    {
+                        await SqlBulkOperation.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken);
+                    }
+                    else if (operationType == OperationType.Truncate)
+                    {
+                        await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
+                    }
+                    else
+                    {
+                        await SqlBulkOperation.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken);
+                    }
                 }
             }
         }

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EFCore.BulkExtensions
 {
-    internal static partial class DbContextBulkTransaction
+    internal static class DbContextBulkTransaction
     {
         public static void Execute<T>(DbContext context, IList<T> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress) where T : class
         {

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -19,7 +19,7 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                if (bulkConfig.IncludeGraph)
+                if (bulkConfig?.IncludeGraph == true)
                 {
                     DbContextBulkTransactionGraphUtil.ExecuteWithGraph(context, entities, operationType, bulkConfig, progress);
                 }
@@ -56,7 +56,7 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                if (bulkConfig.IncludeGraph)
+                if (bulkConfig?.IncludeGraph == true)
                 {
                     DbContextBulkTransactionGraphUtil.ExecuteWithGraph(context, entities, operationType, bulkConfig, progress);
                 }
@@ -93,7 +93,7 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                if (bulkConfig.IncludeGraph)
+                if (bulkConfig?.IncludeGraph == true)
                 {
                     await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken);
                 }
@@ -130,7 +130,7 @@ namespace EFCore.BulkExtensions
                     return;
                 }
 
-                if (bulkConfig.IncludeGraph)
+                if (bulkConfig?.IncludeGraph == true)
                 {
                     await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken);
                 }

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EFCore.BulkExtensions
+{
+    internal static class DbContextBulkTransactionGraphUtil
+    {
+        public static void ExecuteWithGraph(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress)
+        {
+            if (operationType != OperationType.Insert
+                        && operationType != OperationType.InsertOrUpdate
+                        && operationType != OperationType.InsertOrUpdateDelete
+                        && operationType != OperationType.Update)
+                throw new InvalidBulkConfigException($"{nameof(BulkConfig)}.{nameof(BulkConfig.IncludeGraph)} only supports Insert or Update operations.");
+
+            // If this is set to false, won't be able to propogate new primary keys to the relationships
+            bulkConfig.SetOutputIdentity = true;
+
+            var rootGraphItems = GraphUtil.GetOrderedGraph(context, entities);
+
+            if (rootGraphItems == null)
+                return;
+
+            foreach (var actionGraphItem in rootGraphItems)
+            {
+                var entitiesToAction = actionGraphItem.Entities.Select(y => y.Entity).ToList();
+                var tableInfo = TableInfo.CreateInstance(context, actionGraphItem.EntityClrType, entitiesToAction, operationType, bulkConfig);
+
+                SqlBulkOperation.Merge(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress);
+
+                // Loop through the dependants and update their foreign keys with the PK values of the just inserted / merged entities
+                foreach (var graphEntity in actionGraphItem.Entities)
+                {
+                    var entity = graphEntity.Entity;
+                    var parentEntity = graphEntity.ParentEntity;
+
+                    // If the parent entity is null its the root type of the object graph.
+                    if (parentEntity is null)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        var navigation = actionGraphItem.ParentNavigation;
+
+                        if (navigation.IsDependentToPrincipal())
+                        {
+                            SetForeignKeyForRelationship(context, navigation,
+                                dependent: parentEntity,
+                                principal: entity);
+                        }
+                        else
+                        {
+                            SetForeignKeyForRelationship(context, navigation,
+                                dependent: entity,
+                                principal: parentEntity);
+                        }
+                    }
+                }
+            }
+        }
+
+
+        public static async Task ExecuteWithGraphAsync(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress, CancellationToken cancellationToken)
+        {
+            if (operationType != OperationType.Insert
+                        && operationType != OperationType.InsertOrUpdate
+                        && operationType != OperationType.InsertOrUpdateDelete
+                        && operationType != OperationType.Update)
+                throw new InvalidBulkConfigException($"{nameof(BulkConfig)}.{nameof(BulkConfig.IncludeGraph)} only supports Insert or Update operations.");
+
+            // If this is set to false, won't be able to propogate new primary keys to the relationships
+            bulkConfig.SetOutputIdentity = true;
+
+            var rootGraphItems = GraphUtil.GetOrderedGraph(context, entities);
+
+            if (rootGraphItems == null)
+                return;
+
+            foreach (var actionGraphItem in rootGraphItems)
+            {
+                var entitiesToAction = actionGraphItem.Entities.Select(y => y.Entity).ToList();
+                var tableInfo = TableInfo.CreateInstance(context, actionGraphItem.EntityClrType, entitiesToAction, operationType, bulkConfig);
+
+                await SqlBulkOperation.MergeAsync(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress, cancellationToken);
+
+                // Loop through the dependants and update their foreign keys with the PK values of the just inserted / merged entities
+                foreach (var graphEntity in actionGraphItem.Entities)
+                {
+                    var entity = graphEntity.Entity;
+                    var parentEntity = graphEntity.ParentEntity;
+
+                    // If the parent entity is null its the root type of the object graph.
+                    if (parentEntity is null)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        var navigation = actionGraphItem.ParentNavigation;
+
+                        if (navigation.IsDependentToPrincipal())
+                        {
+                            SetForeignKeyForRelationship(context, navigation,
+                                dependent: parentEntity,
+                                principal: entity);
+                        }
+                        else
+                        {
+                            SetForeignKeyForRelationship(context, navigation,
+                                dependent: entity,
+                                principal: parentEntity);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void SetForeignKeyForRelationship(DbContext context, INavigation navigation, object dependent, object principal)
+        {
+            var principalKeyProperties = navigation.ForeignKey.PrincipalKey.Properties;
+            var pkValues = new List<object>();
+
+            foreach (var pk in principalKeyProperties)
+            {
+                var value = context.Entry(principal).Property(pk.Name).CurrentValue;
+                pkValues.Add(value);
+            }
+
+            var dependantKeyProperties = navigation.ForeignKey.Properties;
+
+            for (int i = 0; i < pkValues.Count; i++)
+            {
+                var dk = dependantKeyProperties[i];
+                var pkVal = pkValues[i];
+
+                context.Entry(dependent).Property(dk.Name).CurrentValue = pkVal;
+            }
+        }
+    }
+}

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -136,43 +136,6 @@ namespace EFCore.BulkExtensions
             }
         }
 
-        private class PrimaryKeyComparer : List<object>
-        {
-            public override bool Equals(object obj)
-            {
-                var objCast = obj as PrimaryKeyComparer;
-
-                if (objCast is null)
-                    return base.Equals(objCast);
-
-                if (objCast.Count != this.Count)
-                    return base.Equals(objCast);
-
-                for (int i = 0; i < this.Count; i++)
-                {
-                    var a = this[i];
-                    var b = objCast[i];
-
-                    if (a.Equals(b) == false)
-                        return false;
-                }
-
-                return true;
-            }
-
-            public override int GetHashCode()
-            {
-                int hash = 0xC0FFEE;
-
-                foreach (var x in this)
-                {
-                    hash = hash * 31 + x.GetHashCode();
-                }
-
-                return hash;
-            }
-        }
-
         private static IEnumerable<object> GetUniqueEntities(DbContext context, GraphUtil.GraphItem graphItem)
         {
             var pk = graphItem.EntityType.FindPrimaryKey();
@@ -223,6 +186,43 @@ namespace EFCore.BulkExtensions
                 var pkVal = pkValues[i];
 
                 context.Entry(dependent).Property(dk.Name).CurrentValue = pkVal;
+            }
+        }
+
+        private class PrimaryKeyComparer : List<object>
+        {
+            public override bool Equals(object obj)
+            {
+                var objCast = obj as PrimaryKeyComparer;
+
+                if (objCast is null)
+                    return base.Equals(objCast);
+
+                if (objCast.Count != this.Count)
+                    return base.Equals(objCast);
+
+                for (int i = 0; i < this.Count; i++)
+                {
+                    var a = this[i];
+                    var b = objCast[i];
+
+                    if (a.Equals(b) == false)
+                        return false;
+                }
+
+                return true;
+            }
+
+            public override int GetHashCode()
+            {
+                int hash = 0xC0FFEE;
+
+                foreach (var x in this)
+                {
+                    hash = hash * 31 + x.GetHashCode();
+                }
+
+                return hash;
             }
         }
     }

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,11 +14,17 @@ namespace EFCore.BulkExtensions
     internal static class DbContextBulkTransactionGraphUtil
     {
         public static void ExecuteWithGraph(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress)
+            => ExecuteWithGraphAsync_Impl(context, entities, operationType, bulkConfig, progress, null, isAsync: false).GetAwaiter().GetResult();
+
+        public static Task ExecuteWithGraphAsync(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress, CancellationToken cancellationToken)
+            => ExecuteWithGraphAsync_Impl(context, entities, operationType, bulkConfig, progress, cancellationToken, isAsync: true);
+
+        private static async Task ExecuteWithGraphAsync_Impl(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress, CancellationToken? cancellationToken, bool isAsync = true)
         {
             if (operationType != OperationType.Insert
-                        && operationType != OperationType.InsertOrUpdate
-                        && operationType != OperationType.InsertOrUpdateDelete
-                        && operationType != OperationType.Update)
+                       && operationType != OperationType.InsertOrUpdate
+                       && operationType != OperationType.InsertOrUpdateDelete
+                       && operationType != OperationType.Update)
                 throw new InvalidBulkConfigException($"{nameof(BulkConfig)}.{nameof(BulkConfig.IncludeGraph)} only supports Insert or Update operations.");
 
             // If this is set to false, won't be able to propogate new primary keys to the relationships
@@ -28,96 +35,81 @@ namespace EFCore.BulkExtensions
             if (rootGraphItems == null)
                 return;
 
-            foreach (var actionGraphItem in rootGraphItems)
+            // Inserting an entity graph must be done within a transaction otherwise the database could end up in a bad state
+            var hasExistingTransaction = context.Database.CurrentTransaction != null;
+            var transaction = context.Database.CurrentTransaction ?? (isAsync ? await context.Database.BeginTransactionAsync() : context.Database.BeginTransaction());
+
+            try
             {
-                var entitiesToAction = actionGraphItem.Entities.Select(y => y.Entity).ToList();
-                var tableInfo = TableInfo.CreateInstance(context, actionGraphItem.EntityClrType, entitiesToAction, operationType, bulkConfig);
-
-                SqlBulkOperation.Merge(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress);
-
-                // Loop through the dependants and update their foreign keys with the PK values of the just inserted / merged entities
-                foreach (var graphEntity in actionGraphItem.Entities)
+                foreach (var actionGraphItem in rootGraphItems)
                 {
-                    var entity = graphEntity.Entity;
-                    var parentEntity = graphEntity.ParentEntity;
+                    var entitiesToAction = actionGraphItem.Entities.Select(y => y.Entity).ToList();
+                    var tableInfo = TableInfo.CreateInstance(context, actionGraphItem.EntityClrType, entitiesToAction, operationType, bulkConfig);
 
-                    // If the parent entity is null its the root type of the object graph.
-                    if (parentEntity is null)
+                    if (isAsync)
                     {
-                        continue;
+                        await SqlBulkOperation.MergeAsync(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress, cancellationToken.Value);
                     }
                     else
                     {
-                        var navigation = actionGraphItem.ParentNavigation;
+                        SqlBulkOperation.Merge(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress);
+                    }
+                    
 
-                        if (navigation.IsDependentToPrincipal())
+                    // Loop through the dependants and update their foreign keys with the PK values of the just inserted / merged entities
+                    foreach (var graphEntity in actionGraphItem.Entities)
+                    {
+                        var entity = graphEntity.Entity;
+                        var parentEntity = graphEntity.ParentEntity;
+
+                        // If the parent entity is null its the root type of the object graph.
+                        if (parentEntity is null)
                         {
-                            SetForeignKeyForRelationship(context, navigation,
-                                dependent: parentEntity,
-                                principal: entity);
+                            continue;
                         }
                         else
                         {
-                            SetForeignKeyForRelationship(context, navigation,
-                                dependent: entity,
-                                principal: parentEntity);
+                            var navigation = actionGraphItem.ParentNavigation;
+
+                            if (navigation.IsDependentToPrincipal())
+                            {
+                                SetForeignKeyForRelationship(context, navigation,
+                                    dependent: parentEntity,
+                                    principal: entity);
+                            }
+                            else
+                            {
+                                SetForeignKeyForRelationship(context, navigation,
+                                    dependent: entity,
+                                    principal: parentEntity);
+                            }
                         }
                     }
                 }
-            }
-        }
 
-
-        public static async Task ExecuteWithGraphAsync(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal> progress, CancellationToken cancellationToken)
-        {
-            if (operationType != OperationType.Insert
-                        && operationType != OperationType.InsertOrUpdate
-                        && operationType != OperationType.InsertOrUpdateDelete
-                        && operationType != OperationType.Update)
-                throw new InvalidBulkConfigException($"{nameof(BulkConfig)}.{nameof(BulkConfig.IncludeGraph)} only supports Insert or Update operations.");
-
-            // If this is set to false, won't be able to propogate new primary keys to the relationships
-            bulkConfig.SetOutputIdentity = true;
-
-            var rootGraphItems = GraphUtil.GetOrderedGraph(context, entities);
-
-            if (rootGraphItems == null)
-                return;
-
-            foreach (var actionGraphItem in rootGraphItems)
-            {
-                var entitiesToAction = actionGraphItem.Entities.Select(y => y.Entity).ToList();
-                var tableInfo = TableInfo.CreateInstance(context, actionGraphItem.EntityClrType, entitiesToAction, operationType, bulkConfig);
-
-                await SqlBulkOperation.MergeAsync(context, actionGraphItem.EntityClrType, entitiesToAction, tableInfo, operationType, progress, cancellationToken);
-
-                // Loop through the dependants and update their foreign keys with the PK values of the just inserted / merged entities
-                foreach (var graphEntity in actionGraphItem.Entities)
+                if (hasExistingTransaction == false)
                 {
-                    var entity = graphEntity.Entity;
-                    var parentEntity = graphEntity.ParentEntity;
-
-                    // If the parent entity is null its the root type of the object graph.
-                    if (parentEntity is null)
+                    if (isAsync)
                     {
-                        continue;
+                        await transaction.CommitAsync();
                     }
                     else
                     {
-                        var navigation = actionGraphItem.ParentNavigation;
-
-                        if (navigation.IsDependentToPrincipal())
-                        {
-                            SetForeignKeyForRelationship(context, navigation,
-                                dependent: parentEntity,
-                                principal: entity);
-                        }
-                        else
-                        {
-                            SetForeignKeyForRelationship(context, navigation,
-                                dependent: entity,
-                                principal: parentEntity);
-                        }
+                        transaction.Commit();
+                    }
+                }
+            }
+            finally
+            {
+                if (hasExistingTransaction == false)
+                {
+                    if (isAsync)
+                    {
+                        await transaction.DisposeAsync();
+                    }
+                    else
+                    {
+                        transaction.Dispose();
                     }
                 }
             }

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -162,7 +162,7 @@ namespace EFCore.BulkExtensions
                 }
                 else
                 {
-                    yield return entry;
+                    yield return entity;
                 }
             }
         }

--- a/EFCore.BulkExtensions/GraphUtil.cs
+++ b/EFCore.BulkExtensions/GraphUtil.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -27,6 +28,8 @@ namespace EFCore.BulkExtensions
         {
             public object Entity { get; set; }
             public object ParentEntity { get; set; }
+
+            public INavigation InboundNavigation { get; set; }
         }
 
         public static IEnumerable<GraphItem> GetOrderedGraph(DbContext dbContext, IEnumerable<object> entities)
@@ -41,7 +44,7 @@ namespace EFCore.BulkExtensions
 
             foreach (var e in entities)
             {
-                dbContext.ChangeTracker.TrackGraph(e, TrackGraphCallback(entityGraphMap, result));
+                BuildRelationshipGraph(dbContext, new GraphEntity { Entity = e }, entityGraphMap, result);
             }
 
             var ordered = result.OrderBy((x) =>
@@ -75,71 +78,104 @@ namespace EFCore.BulkExtensions
             return ordered;
         }
 
-        private static Action<EntityEntryGraphNode> TrackGraphCallback(IDictionary<object, GraphItem> entityGraphMap, ICollection<GraphItem> result)
+        private static void BuildRelationshipGraph(DbContext dbContext, GraphEntity graphEntity, IDictionary<object, GraphItem> entityGraphMap, ICollection<GraphItem> result)
         {
-            return (graphNode) =>
+            var entryEntity = graphEntity.Entity;
+            var entryEntityType = entryEntity.GetType();
+            var entityType = dbContext.Model.FindEntityType(entryEntityType);
+            var sourceEntryEntity = graphEntity.ParentEntity;
+
+            GraphItem parentGraphItem;
+            GraphItem graphItem;
+
+            if (sourceEntryEntity != null)
             {
-                var entryEntity = graphNode.Entry.Entity;
-                var entryEntityType = entryEntity.GetType();
-                var sourceEntryEntity = graphNode.SourceEntry?.Entity;
-                var graphEntity = new GraphEntity
+                parentGraphItem = entityGraphMap[sourceEntryEntity];
+                graphItem = parentGraphItem.Relationships.FirstOrDefault(y => y.EntityClrType == entryEntityType);
+            }
+            else
+            {
+                parentGraphItem = null;
+                graphItem = result.FirstOrDefault(y => y.EntityClrType == entryEntityType);
+            }
+
+            if (graphItem is null)
+            {
+                graphItem = new GraphItem
                 {
-                    Entity = entryEntity,
-                    ParentEntity = sourceEntryEntity
+                    EntityClrType = entryEntityType,
+                    Entities =
+                    {
+                        graphEntity
+                    },
+                    Parent = parentGraphItem,
+                    ParentNavigation = graphEntity.InboundNavigation
                 };
 
-                // Set to unchanged if they are detached otherwise EFCore won't traverse the graph
-                if (graphNode.Entry.State == EntityState.Detached)
-                {
-                    if (graphNode.Entry.IsKeySet)
-                    {
-                        graphNode.Entry.State = EntityState.Unchanged;
-                    }
-                    else
-                    {
-                        graphNode.Entry.State = EntityState.Added;
-                    }
-                }
+                if (parentGraphItem != null)
+                    parentGraphItem.Relationships.Add(graphItem);
+            }
+            else
+            {
+                graphItem.Entities.Add(graphEntity);
+            }
 
-                GraphItem parentGraphItem;
-                GraphItem graphItem;
-
-                if (sourceEntryEntity != null)
-                {
-                    parentGraphItem = entityGraphMap[sourceEntryEntity];
-                    graphItem = parentGraphItem.Relationships.FirstOrDefault(y => y.EntityClrType == entryEntityType);
-                }
-                else
-                {
-                    parentGraphItem = null;
-                    graphItem = null;
-                }
-
-                if (graphItem is null)
-                {
-                    graphItem = new GraphItem
-                    {
-                        EntityClrType = entryEntityType,
-                        Entities =
-                        {
-                            graphEntity
-                        },
-                        Parent = parentGraphItem,
-                        ParentNavigation = graphNode.InboundNavigation
-                    };
-
-                    if (parentGraphItem != null)
-                        parentGraphItem.Relationships.Add(graphItem);
-                }
-                else
-                {
-                    graphItem.Entities.Add(graphEntity);
-                }
-
-                // Always track in case the entryEntity has dependents
+            // Always track in case the entryEntity has dependents
+            if (entityGraphMap.ContainsKey(entryEntity) == false)
                 entityGraphMap.Add(entryEntity, graphItem);
-                result.Add(graphItem);
-            };
+
+            result.Add(graphItem);
+            EnumerateRelationshipValues(dbContext, entryEntity, entityType, entityGraphMap, result);
+        }
+
+        private static void EnumerateRelationshipValues(DbContext dbContext, object entryEntity, IEntityType entityType, IDictionary<object, GraphItem> entityGraphMap, ICollection<GraphItem> result)
+        {
+            var entityNavigations = entityType.GetNavigations();
+
+            foreach (var navigation in entityNavigations)
+            {
+                if (navigation.IsCollection())
+                {
+                    var navigationValue = dbContext.Entry(entryEntity).Collection(navigation.Name).CurrentValue;
+
+                    if (navigationValue is null)
+                        continue;
+
+                    var navigationCollectionValue = navigationValue.Cast<object>().ToList();
+
+                    foreach (var navEntity in navigationCollectionValue)
+                    {
+                        BuildRelationshipGraph(
+                            dbContext: dbContext,
+                            graphEntity: new GraphEntity
+                            {
+                                Entity = navEntity,
+                                ParentEntity = entryEntity,
+                                InboundNavigation = navigation
+                            },
+                            entityGraphMap: entityGraphMap,
+                            result: result);
+                    }
+                }
+                else
+                {
+                    var navigationValue = dbContext.Entry(entryEntity).Reference(navigation.Name).CurrentValue;
+
+                    if (navigationValue is null)
+                        continue;
+
+                    BuildRelationshipGraph(
+                        dbContext: dbContext,
+                        graphEntity: new GraphEntity
+                        {
+                            Entity = navigationValue,
+                            ParentEntity = entryEntity,
+                            InboundNavigation = navigation
+                        },
+                        entityGraphMap: entityGraphMap,
+                        result: result);
+                }
+            }
         }
     }
 }

--- a/EFCore.BulkExtensions/GraphUtil.cs
+++ b/EFCore.BulkExtensions/GraphUtil.cs
@@ -1,0 +1,145 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace EFCore.BulkExtensions
+{
+    internal class GraphUtil
+    {
+        public class GraphItem
+        {
+            public Type EntityClrType { get; set; }
+            public IEntityType EntityType { get; set; }
+            public IList<GraphEntity> Entities { get; set; } = new List<GraphEntity>();
+
+            public INavigation ParentNavigation { get; set; }
+            public GraphItem Parent { get; set; }
+            public ICollection<GraphItem> Relationships { get; set; } = new List<GraphItem>();
+        }
+
+        public class GraphEntity
+        {
+            public object Entity { get; set; }
+            public object ParentEntity { get; set; }
+        }
+
+        public static IEnumerable<GraphItem> GetOrderedGraph(DbContext dbContext, IEnumerable<object> entities)
+        {
+            if (!entities.Any())
+            {
+                return null;
+            }
+
+            var entityGraphMap = new Dictionary<object, GraphItem>();
+            var result = new HashSet<GraphItem>();
+
+            foreach (var e in entities)
+            {
+                dbContext.ChangeTracker.TrackGraph(e, TrackGraphCallback(entityGraphMap, result));
+            }
+
+            var ordered = result.OrderBy((x) =>
+            {
+                if (x.Parent is null)
+                {
+                    for (int i = 0; i < x.Relationships.Count; i++)
+                    {
+                        var r = x.Relationships.ElementAt(i);
+
+                        // If x's side of the relationship is dependent on the other side of the relationship
+                        if (r.ParentNavigation.IsDependentToPrincipal())
+                            // Return true to push it further down the list
+                            return true;
+                    }
+
+                    // If x is not dependent on any of its relationships, push it up the list
+                    return false;
+                }
+
+                // If the other side of the relationship is dependent on x
+                if (x.ParentNavigation.IsDependentToPrincipal())
+                {
+                    // return false to push it up the list
+                    return false;
+                }
+
+                return true;
+            }).ToList();
+
+            return ordered;
+        }
+
+        private static Action<EntityEntryGraphNode> TrackGraphCallback(IDictionary<object, GraphItem> entityGraphMap, ICollection<GraphItem> result)
+        {
+            return (graphNode) =>
+            {
+                var entryEntity = graphNode.Entry.Entity;
+                var entryEntityType = entryEntity.GetType();
+                var sourceEntryEntity = graphNode.SourceEntry?.Entity;
+                var graphEntity = new GraphEntity
+                {
+                    Entity = entryEntity,
+                    ParentEntity = sourceEntryEntity
+                };
+
+                // Set to unchanged if they are detached otherwise EFCore won't traverse the graph
+                if (graphNode.Entry.State == EntityState.Detached)
+                {
+                    if (graphNode.Entry.IsKeySet)
+                    {
+                        graphNode.Entry.State = EntityState.Unchanged;
+                    }
+                    else
+                    {
+                        graphNode.Entry.State = EntityState.Added;
+                    }
+                }
+
+                GraphItem parentGraphItem;
+                GraphItem graphItem;
+
+                if (sourceEntryEntity != null)
+                {
+                    parentGraphItem = entityGraphMap[sourceEntryEntity];
+                    graphItem = parentGraphItem.Relationships.FirstOrDefault(y => y.EntityClrType == entryEntityType);
+                }
+                else
+                {
+                    parentGraphItem = null;
+                    graphItem = null;
+                }
+
+                if (graphItem is null)
+                {
+                    graphItem = new GraphItem
+                    {
+                        EntityClrType = entryEntityType,
+                        Entities =
+                        {
+                            graphEntity
+                        },
+                        Parent = parentGraphItem,
+                        ParentNavigation = graphNode.InboundNavigation
+                    };
+
+                    if (parentGraphItem != null)
+                        parentGraphItem.Relationships.Add(graphItem);
+                }
+                else
+                {
+                    graphItem.Entities.Add(graphEntity);
+                }
+
+                // Always track in case the entryEntity has dependents
+                entityGraphMap.Add(entryEntity, graphItem);
+                result.Add(graphItem);
+            };
+        }
+    }
+}

--- a/EFCore.BulkExtensions/GraphUtil.cs
+++ b/EFCore.BulkExtensions/GraphUtil.cs
@@ -104,6 +104,7 @@ namespace EFCore.BulkExtensions
                 graphItem = new GraphItem
                 {
                     EntityClrType = entryEntityType,
+                    EntityType = entityType,
                     Entities =
                     {
                         graphEntity

--- a/EFCore.BulkExtensions/InvalidBulkConfigException.cs
+++ b/EFCore.BulkExtensions/InvalidBulkConfigException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EFCore.BulkExtensions
+{
+    [Serializable]
+    public class InvalidBulkConfigException : Exception
+    {
+        public InvalidBulkConfigException()
+        {
+        }
+
+        public InvalidBulkConfigException(string message) : base(message)
+        {
+        }
+
+        public InvalidBulkConfigException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected InvalidBulkConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -467,12 +467,15 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
 
             type = tableInfo.HasAbstractList ? entities[0].GetType() : type;
             var entityType = context.Model.FindEntityType(type);
-            var entityPropertiesDict = entityType.GetProperties().Where(a => tableInfo.PropertyColumnNamesDict.ContainsKey(a.Name)).ToDictionary(a => a.Name, a => a);
+            var entityTypeProperties = entityType.GetProperties();
+            var entityPropertiesDict = entityTypeProperties.Where(a => tableInfo.PropertyColumnNamesDict.ContainsKey(a.Name)).ToDictionary(a => a.Name, a => a);
             var entityNavigationOwnedDict = entityType.GetNavigations().Where(a => a.GetTargetType().IsOwned()).ToDictionary(a => a.Name, a => a);
-            var entityShadowFkPropertiesDict = entityType.GetProperties().Where(a => a.IsShadowProperty() && 
-                                                                                     a.IsForeignKey() &&
-                                                                                     a.GetContainingForeignKeys().FirstOrDefault()?.DependentToPrincipal?.Name != null)
-                                                                         .ToDictionary(x => x.GetContainingForeignKeys().First().DependentToPrincipal.Name, a => a);
+            var entityShadowFkPropertiesDict = entityTypeProperties.Where(a => 
+                a.IsShadowProperty() && 
+                a.IsForeignKey() &&
+                a.GetContainingForeignKeys().FirstOrDefault()?.DependentToPrincipal?.Name != null)
+                .ToDictionary(x => x.Name, a => a);
+
             var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             var discriminatorColumn = GetDiscriminatorColumn(tableInfo);
 

--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -588,6 +588,11 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
                 foreach (var sp in entityPropertiesDict.Values.Where(y => y.IsShadowProperty()))
                 {
                     var columnName = sp.GetColumnName();
+
+                    // If a model has an entity which has a relationship without an explicity defined FK, the data table will already contain the foreign key shadow property
+                    if (dataTable.Columns.Contains(columnName))
+                        continue;
+                    
                     var isConvertible = tableInfo.ConvertibleProperties.ContainsKey(columnName);
                     var propertyType = isConvertible ? tableInfo.ConvertibleProperties[columnName].ProviderClrType : sp.ClrType;
 


### PR DESCRIPTION
Insert, update or merge the entire entity object graph. Does not support Sqlite due to how its set output identity = true implementation works.

```csharp
private static WorkOrder WorkOrder1 = new WorkOrder
{
    Description = "Fix belt",
    Asset = new Asset
    {
        Description = "MANU-1",
        Location = "WAREHOUSE-1"
    },
    WorkOrderSpares =
        {
            new WorkOrderSpare
            {
                Description = "Bolt 5mm x5",
                Quantity = 5,
                Spare = new Spare
                {
                    PartNumber = "MZD 5mm",
                    Barcode = "12345"
                }
            },
            new WorkOrderSpare
            {
                Description = "Bolt 10mm x5",
                Quantity = 5,
                Spare = new Spare
                {
                    PartNumber = "MZD 10mm",
                    Barcode = "222655"
                }
            }
        }
};

private IEnumerable<WorkOrder> GetTestData(DbContext db)
{
    yield return WorkOrder1;
}

var testData = this.GetTestData(db).ToList();
await db.BulkInsertOrUpdateAsync(testData, new BulkConfig
{
    IncludeGraph = true
});
```