### PR TITLE
BulkInsert problem when primary key has be defined ColumnName and SetOutputIdentity is true.

### DIFF
--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -72,7 +72,7 @@ namespace EFCore.BulkExtensions
         public static string SelectFromOutputTable(TableInfo tableInfo)
         {
             List<string> columnsNames = tableInfo.OutputPropertyColumnNamesDict.Values.ToList();
-            var q = $"SELECT {GetCommaSeparatedColumns(columnsNames)} FROM {tableInfo.FullTempOutputTableName} WHERE [{tableInfo.PrimaryKeys.FirstOrDefault()}] IS NOT NULL";
+            var q = $"SELECT {GetCommaSeparatedColumns(columnsNames)} FROM {tableInfo.FullTempOutputTableName} WHERE [{tableInfo.PrimaryKeys.Select(x => x.Value).FirstOrDefault()}] IS NOT NULL";
             return q;
         }
 
@@ -133,7 +133,7 @@ namespace EFCore.BulkExtensions
             string sourceTable = tableInfo.FullTableName;
             string joinTable = tableInfo.FullTempTableName;
             List<string> columnsNames = tableInfo.PropertyColumnNamesDict.Values.ToList();
-            List<string> selectByPropertyNames = tableInfo.PropertyColumnNamesDict.Where(a => tableInfo.PrimaryKeys.Contains(a.Key)).Select(a => a.Value).ToList();
+            List<string> selectByPropertyNames = tableInfo.PropertyColumnNamesDict.Where(a => tableInfo.PrimaryKeys.ContainsKey(a.Key)).Select(a => a.Value).ToList();
 
             var q = $"SELECT {GetCommaSeparatedColumns(columnsNames, "S")} FROM {sourceTable} AS S " +
                     $"JOIN {joinTable} AS J " +
@@ -153,7 +153,7 @@ namespace EFCore.BulkExtensions
             string targetTable = tableInfo.FullTableName;
             string sourceTable = tableInfo.FullTempTableName;
             bool keepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions.HasFlag(SqlBulkCopyOptions.KeepIdentity);
-            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
+            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k.Key]).ToList();
             List<string> columnsNames = tableInfo.PropertyColumnNamesDict.Values.ToList();
             List<string> columnsNamesOnCompare = tableInfo.PropertyColumnNamesCompareDict.Values.ToList();
             List<string> columnsNamesOnUpdate = tableInfo.PropertyColumnNamesUpdateDict.Values.ToList();

--- a/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilderSqlite.cs
@@ -34,7 +34,7 @@ namespace EFCore.BulkExtensions
 
             if (operationType == OperationType.InsertOrUpdate)
             {
-                List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
+                List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k.Key]).ToList();
                 var commaSeparatedPrimaryKeys = SqlQueryBuilder.GetCommaSeparatedColumns(primaryKeys);
                 var commaSeparatedColumnsEquals = SqlQueryBuilder.GetCommaSeparatedColumns(columnsList, equalsTable: "", propertColumnsNamesDict: tableInfo.PropertyColumnNamesDict).Replace("]", "").Replace(" = .[", "] = @").Replace(".", "_");
                 var commaANDSeparatedPrimaryKeys = SqlQueryBuilder.GetANDSeparatedColumns(primaryKeys, equalsTable: "@", propertColumnsNamesDict: tableInfo.PropertyColumnNamesDict).Replace("]", "").Replace(" = @[", "] = @").Replace(".", "_");
@@ -50,7 +50,7 @@ namespace EFCore.BulkExtensions
         {
             tableName = tableName ?? tableInfo.TableName;
             List<string> columnsList = tableInfo.PropertyColumnNamesDict.Values.ToList();
-            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
+            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k.Key]).ToList();
             var commaSeparatedColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsList, equalsTable: "@", propertColumnsNamesDict: tableInfo.PropertyColumnNamesDict).Replace("]", "").Replace(" = @[", "] = @").Replace(".", "_"); ;
             var commaSeparatedPrimaryKeys = SqlQueryBuilder.GetANDSeparatedColumns(primaryKeys, equalsTable: "@", propertColumnsNamesDict: tableInfo.PropertyColumnNamesDict).Replace("]", "").Replace(" = @[", "] = @").Replace(".", "_"); ;
 
@@ -63,7 +63,7 @@ namespace EFCore.BulkExtensions
         public static string DeleteFromTable(TableInfo tableInfo, string tableName = null)
         {
             tableName = tableName ?? tableInfo.TableName;
-            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k]).ToList();
+            List<string> primaryKeys = tableInfo.PrimaryKeys.Select(k => tableInfo.PropertyColumnNamesDict[k.Key]).ToList();
             var commaSeparatedPrimaryKeys = SqlQueryBuilder.GetANDSeparatedColumns(primaryKeys, equalsTable: "@", propertColumnsNamesDict: tableInfo.PropertyColumnNamesDict).Replace("]", "").Replace(" = @[", "] = @").Replace(".", "_");
 
             var q = $"DELETE FROM [{tableName}] " +


### PR DESCRIPTION
BulkInsert problem when primary key has be defined ColumnName and SetOutputIdentity is true.

Problem:

Mapping sample:

        builderModel.ToTable("TableSample", "dbo");

        builderModel.Property(x => x.Id)
            .HasColumnName("ID_TS")
            .IsRequired();

        builderModel.HasKey(x => x.Id);
        .
        .
        . 
Select generated on TempTable:

SELECT [r].[ID_TS], ...
FROM (
SELECT [ID_TS], ... FROM [dbo].[TableSample431421f7Output] WHERE **_[Id]_** IS NOT NULL
) AS [r]
ORDER BY [r].[ID_TS]

Generated "where" with property name than [ID_TS] (property column name).