### PR TITLE
Fix BatchDelete and BatchUpdate with where expression and ValueConverter

### DIFF
--- a/EFCore.BulkExtensions.Tests/ValueConverters/VcDbContext.cs
+++ b/EFCore.BulkExtensions.Tests/ValueConverters/VcDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
@@ -24,7 +25,26 @@ namespace EFCore.BulkExtensions.Tests.ValueConverters
 
                 cfg.Property(y => y.Enum).HasColumnType("nvarchar(4000)").HasConversion<string>();
 
+                cfg.Property(y => y.LocalDate).HasColumnType("date").HasConversion(new LocalDateValueConverter());
             });
+        }
+
+        public class LocalDateValueConverter : ValueConverter<LocalDate, DateTime>
+        {
+            public LocalDateValueConverter()
+            : base((LocalDate i) => ToProvider(i), (DateTime d) => FromProvider(d), null)
+            {
+            }
+
+            private static DateTime ToProvider(LocalDate localDate)
+            {
+                return new DateTime(localDate.Year, localDate.Month, localDate.Day, 0, 0, 0, DateTimeKind.Unspecified);
+            }
+
+            private static LocalDate FromProvider(DateTime dateTime)
+            {
+                return new LocalDate(dateTime.Year, dateTime.Month, dateTime.Day);
+            }
         }
     }
 }

--- a/EFCore.BulkExtensions.Tests/ValueConverters/VcModel.cs
+++ b/EFCore.BulkExtensions.Tests/ValueConverters/VcModel.cs
@@ -9,6 +9,8 @@ namespace EFCore.BulkExtensions.Tests.ValueConverters
         public int Id { get; set; }
 
         public VcEnum Enum { get; set; }
+
+        public LocalDate LocalDate { get; set; }
     }
 
     public enum VcEnum
@@ -16,5 +18,29 @@ namespace EFCore.BulkExtensions.Tests.ValueConverters
         Why,
         Hello,
         There
+    }
+
+    public readonly struct LocalDate
+    {
+        public LocalDate(int year, int month, int day)
+        {
+            this.Year = year;
+            this.Month = month;
+            this.Day = day;
+        }
+
+        public readonly int Year;
+        public readonly int Month;
+        public readonly int Day;
+
+        public static bool operator >(LocalDate lhs, LocalDate rhs)
+        {
+            return false;
+        }
+
+        public static bool operator <(LocalDate lhs, LocalDate rhs)
+        {
+            return false;
+        }
     }
 }

--- a/EFCore.BulkExtensions/BatchUpdateCreateBodyData.cs
+++ b/EFCore.BulkExtensions/BatchUpdateCreateBodyData.cs
@@ -40,7 +40,6 @@ namespace EFCore.BulkExtensions
             var tableInfo = TableInfo.CreateInstance(dbContext, rootType, Array.Empty<object>(), OperationType.Read, _tableInfoBulkConfig);
             _tableInfoLookup.Add(rootType, tableInfo);
 
-            CheckAndSetParametersForConvertibles(dbContext, innerParameters, tableInfo);
             SqlParameters = new List<object>(innerParameters);
 
             foreach (Match match in BatchUtil.TableAliasPattern.Matches(baseSql))
@@ -60,34 +59,6 @@ namespace EFCore.BulkExtensions
         public List<string> TableAliasesInUse { get; }
         public StringBuilder UpdateColumnsSql { get; }
         public LambdaExpression UpdateExpression { get; }
-
-        protected void CheckAndSetParametersForConvertibles(DbContext context, IEnumerable<object> innerParameters, TableInfo tableInfo) // fix for enum 'int' Conversion to nvarchar
-        {
-            foreach (var innerParameter in innerParameters)
-            {
-                string parameterColumnName = ((Microsoft.Data.SqlClient.SqlParameter)innerParameter).ParameterName.Replace("@__", ""); // @__column_N..
-                parameterColumnName = parameterColumnName.Contains("_") ? parameterColumnName.Substring(0, parameterColumnName.IndexOf("_")) : parameterColumnName; // column
-                parameterColumnName = parameterColumnName.ToLower();
-
-                foreach (var convertibleProperty in tableInfo.ConvertibleProperties)
-                {
-                    if (convertibleProperty.Key.ToLower() == parameterColumnName)
-                    {
-                        if (convertibleProperty.Value.ProviderClrType.Name == nameof(String))
-                        {
-                            if (SqlClientHelper.IsSystemConnection(context.Database.GetDbConnection()))
-                            {
-                                ((System.Data.SqlClient.SqlParameter)innerParameter).DbType = System.Data.DbType.String;
-                            }
-                            else
-                            {
-                                ((Microsoft.Data.SqlClient.SqlParameter)innerParameter).DbType = System.Data.DbType.String;
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
         public TableInfo GetTableInfoForType(Type typeToLookup)
         {


### PR DESCRIPTION
Hello again :)

When using something like:
```c#
var date = new LocalDate(2020, 3, 21);
dbContext.Model.Where(x => x.LocalDate > date).BatchDelete()
```

I got this exception:
```c#
System.ArgumentException: No mapping exists from object type EFCore.BulkExtensions.Tests.ValueConverters.LocalDate to a known managed provider native type.
	at Microsoft.Data.SqlClient.MetaType.GetMetaTypeFromValue(Type dataType, Object value, Boolean inferLen, Boolean streamAllowed)
	at Microsoft.Data.SqlClient.MetaType.GetMetaTypeFromType(Type dataType)
	at Microsoft.Data.SqlClient.SqlParameter.GetMetaTypeOnly()
	at Microsoft.Data.SqlClient.SqlParameter.get_DbType()
	at EFCore.BulkExtensions.SQLAdapters.SQLServer.SqlServerDialect.ReloadSqlParameters(DbContext context, List`1 sqlParameters)
	at EFCore.BulkExtensions.BatchUtil.ReloadSqlParameters(DbContext context, List`1 sqlParameters)
	at EFCore.BulkExtensions.BatchUtil.GetSqlDelete(IQueryable query, DbContext context)
	...
```

The problem was that `CheckAndSetParametersForConvertibles` only applied the converter when `if (convertibleProperty.Key.ToLower() == parameterColumnName)` and that isn't the case here: `convertibleProperty.Key = 'LocalDate'` and `parameterColumnName = 'date'`.  And also the `CheckAndSetParametersForConvertibles` only worked when dealing with a string database type.

The solution is to let EF Core convert the parameter itself using `IRelationalParameter.AddDbParameter(dbCommand, values);` in `ToParametrizedSql()`.
	
I'm not sure if this fix also needs to be in the else part of `ToParametrizedSql()` when `relationalCommandCache == null`, because I have no clue how to trigger that branch with EF Core 3.1 ... 


