### PR TITLE
InsertIfNotExists methods.

### DIFF
--- a/EFCore.BulkExtensions/DbContextBulkExtensions.cs
+++ b/EFCore.BulkExtensions/DbContextBulkExtensions.cs
@@ -57,6 +57,30 @@ namespace EFCore.BulkExtensions
             DbContextBulkTransaction.Execute(context, entityType, entities, OperationType.InsertOrUpdate, bulkConfig, progress);
         }
 
+        public static void BulkInsertIfNotExists<T>(this DbContext context, IList<T> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null) where T : class
+        {
+            DbContextBulkTransaction.Execute(context, entities, OperationType.InsertIfNotExists, bulkConfig, progress);
+        }
+
+        public static void BulkInsertIfNotExists(this DbContext context, Type entityType, IList<object> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null)
+        {
+            DbContextBulkTransaction.Execute(context, entityType, entities, OperationType.InsertIfNotExists, bulkConfig, progress);
+        }
+
+        public static void BulkInsertIfNotExists<T>(this DbContext context, IList<T> entities, Action<BulkConfig> bulkAction, Action<decimal> progress = null) where T : class
+        {
+            BulkConfig bulkConfig = new BulkConfig();
+            bulkAction?.Invoke(bulkConfig);
+            DbContextBulkTransaction.Execute(context, entities, OperationType.InsertIfNotExists, bulkConfig, progress);
+        }
+
+        public static void BulkInsertIfNotExists(this DbContext context, Type entityType, IList<object> entities, Action<BulkConfig> bulkAction, Action<decimal> progress = null)
+        {
+            BulkConfig bulkConfig = new BulkConfig();
+            bulkAction?.Invoke(bulkConfig);
+            DbContextBulkTransaction.Execute(context, entityType, entities, OperationType.InsertIfNotExists, bulkConfig, progress);
+        }
+
         public static void BulkInsertOrUpdateOrDelete<T>(this DbContext context, IList<T> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null) where T : class
         {
             DbContextBulkTransaction.Execute(context, entities, OperationType.InsertOrUpdateDelete, bulkConfig, progress);
@@ -211,6 +235,30 @@ namespace EFCore.BulkExtensions
             BulkConfig bulkConfig = new BulkConfig();
             bulkAction?.Invoke(bulkConfig);
             return DbContextBulkTransaction.ExecuteAsync(context, entityType, entities, OperationType.InsertOrUpdate, bulkConfig, progress, cancellationToken);
+        }
+
+        public static Task BulkInsertIfNotExistsAsync<T>(this DbContext context, IList<T> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null, CancellationToken cancellationToken = default) where T : class
+        {
+            return DbContextBulkTransaction.ExecuteAsync(context, entities, OperationType.InsertIfNotExists, bulkConfig, progress, cancellationToken);
+        }
+
+        public static Task BulkInsertIfNotExistsAsync(this DbContext context, Type entityType, IList<object> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null, CancellationToken cancellationToken = default)
+        {
+            return DbContextBulkTransaction.ExecuteAsync(context, entityType, entities, OperationType.InsertIfNotExists, bulkConfig, progress, cancellationToken);
+        }
+
+        public static Task BulkInsertIfNotExistsAsync<T>(this DbContext context, IList<T> entities, Action<BulkConfig> bulkAction, Action<decimal> progress = null, CancellationToken cancellationToken = default) where T : class
+        {
+            BulkConfig bulkConfig = new BulkConfig();
+            bulkAction?.Invoke(bulkConfig);
+            return DbContextBulkTransaction.ExecuteAsync(context, entities, OperationType.InsertIfNotExists, bulkConfig, progress, cancellationToken);
+        }
+
+        public static Task BulkInsertIfNotExistsAsync(this DbContext context, Type entityType, IList<object> entities, Action<BulkConfig> bulkAction, Action<decimal> progress = null, CancellationToken cancellationToken = default)
+        {
+            BulkConfig bulkConfig = new BulkConfig();
+            bulkAction?.Invoke(bulkConfig);
+            return DbContextBulkTransaction.ExecuteAsync(context, entityType, entities, OperationType.InsertIfNotExists, bulkConfig, progress, cancellationToken);
         }
 
         public static Task BulkInsertOrUpdateOrDeleteAsync<T>(this DbContext context, IList<T> entities, BulkConfig bulkConfig = null, Action<decimal> progress = null, CancellationToken cancellationToken = default) where T : class

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -12,6 +12,7 @@ namespace EFCore.BulkExtensions
         Insert,
         InsertOrUpdate,
         InsertOrUpdateDelete,
+        InsertIfNotExists,
         Update,
         Delete,
         Read,

--- a/EFCore.BulkExtensions/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlQueryBuilder.cs
@@ -178,7 +178,7 @@ namespace EFCore.BulkExtensions
                     $"ON {GetANDSeparatedColumns(primaryKeys, "T", "S", tableInfo.UpdateByPropertiesAreNullable)}";
             q += (primaryKeys.Count() == 0) ? "1=0" : "";
 
-            if (operationType == OperationType.Insert || operationType == OperationType.InsertOrUpdate || operationType == OperationType.InsertOrUpdateDelete)
+            if (operationType == OperationType.Insert || operationType == OperationType.InsertOrUpdate || operationType == OperationType.InsertOrUpdateDelete || operationType == OperationType.InsertIfNotExists)
             {
                 q += $" WHEN NOT MATCHED BY TARGET THEN INSERT ({GetCommaSeparatedColumns(insertColumnsNames)})" +
                      $" VALUES ({GetCommaSeparatedColumns(insertColumnsNames, "S")})";
@@ -210,7 +210,7 @@ namespace EFCore.BulkExtensions
             if (tableInfo.CreatedOutputTable)
             {
                 string commaSeparatedColumnsNames;
-                if (operationType == OperationType.InsertOrUpdateDelete || operationType == OperationType.Delete)
+                if (operationType == OperationType.InsertOrUpdateDelete || operationType == OperationType.Delete || operationType == OperationType.InsertIfNotExists)
                 {
                     commaSeparatedColumnsNames = string.Join(", ", outputColumnsNames.Select(x => $"COALESCE(INSERTED.[{x}], DELETED.[{x}])"));
                 }


### PR DESCRIPTION
Great library.
I'm trying to add InsertIfNotExists(+async) method. Because trick with:
`PropertiesToIncludeOnUpdate = new List<string> { "" }`
is not working now (exception about unknown property is thrown and empty property list works incorrectly).
This helper can help for issues likes those:
#321 
#189 

I have no idea, how to write tests for this.
So i check this patch only on SQL server in my work projects.
SQLLite i didn't touch.

Thank you for this library!