### PR TITLE
BulkInsertOrUpdateOrDelete should delete when no entities to insert or update

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -306,6 +306,17 @@ namespace EFCore.BulkExtensions.Tests
             {
                 Assert.NotNull(context.Items.Where(x => x.ItemId == keepEntityItemId.Value).FirstOrDefault());
             }
+
+            if (isBulk)
+            {
+                var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true };
+                bulkConfig.SetSynchronizeFilter<Item>(e => e.ItemId != keepEntityItemId.Value);
+                context.BulkInsertOrUpdateOrDelete(new List<Item>(), bulkConfig);
+
+                var storedEntities = context.Items.ToList();
+                Assert.Single(storedEntities);
+                Assert.Equal(3, storedEntities[0].ItemId);
+            }
         }
 
         private void RunUpdate(bool isBulk, DbServer dbServer)

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -301,6 +301,17 @@ namespace EFCore.BulkExtensions.Tests
             {
                 Assert.NotNull(context.Items.Where(x => x.ItemId == keepEntityItemId.Value).FirstOrDefault());
             }
+
+            if (isBulk)
+            {
+                var bulkConfig = new BulkConfig() { SetOutputIdentity = true, CalculateStats = true };
+                bulkConfig.SetSynchronizeFilter<Item>(e => e.ItemId != keepEntityItemId.Value);
+                await context.BulkInsertOrUpdateOrDeleteAsync(new List<Item>(), bulkConfig);
+
+                var storedEntities = contextRead.Items.ToList();
+                Assert.Single(storedEntities);
+                Assert.Equal(3, storedEntities[0].ItemId);
+            }
         }
 
         private async Task RunUpdateAsync(bool isBulk, DbServer dbServer)

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -13,7 +13,7 @@ namespace EFCore.BulkExtensions
             type ??= typeof(T);
             using (ActivitySources.StartExecuteActivity(operationType, entities.Count))
             {
-                if (operationType != OperationType.Truncate && entities.Count == 0)
+                if ((operationType != OperationType.Truncate && operationType != OperationType.InsertOrUpdateDelete) && entities.Count == 0)
                 {
                     return;
                 }
@@ -51,7 +51,7 @@ namespace EFCore.BulkExtensions
             type ??= typeof(T);
             using (ActivitySources.StartExecuteActivity(operationType, entities.Count))
             {
-                if (operationType != OperationType.Truncate && entities.Count == 0)
+                if ((operationType != OperationType.Truncate && operationType != OperationType.InsertOrUpdateDelete) && entities.Count == 0)
                 {
                     return;
                 }


### PR DESCRIPTION
Bugfix for `BulkInsertOrUpdateOrDelete` that wasn't deleting existing entities from the DB when there were 0 entities to insert/update.

I briefly considered adding a fast path like
```c#
if (entities.Count > 0)
{
    SqlBulkOperation.Merge(...);
}
else
{
    IQueryable<TEntity> queryable = context.Set<TEntity>().IgnoreQueryFilters();
    if (bulkConfig.SynchronizeFilter != null)
    {
        queryable = queryable.Where(bulkConfig.SynchronizeFilter);
    }
    queryable.BatchDelete();
}

```
but then reasoned that it might be better to keep things simple and if the caller really wants the performance benefit, he can do it himself easily.


