### PR TITLE
Various OwnedType fixes and resolve issue 547

### DIFF
--- a/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/IncludeGraphTests.cs
@@ -86,6 +86,7 @@ namespace EFCore.BulkExtensions.Tests.IncludeGraph
             ContextUtil.DbServer = dbServer;
 
             using var db = new GraphDbContext(ContextUtil.GetOptions<GraphDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Graph"));
+            await db.Database.EnsureCreatedAsync();
 
             // To ensure there are no stack overflows with circular reference trees, we must test for that.
             // Set all navigation properties so the base navigation and its inverse both have values

--- a/EFCore.BulkExtensions.Tests/IncludeGraph/Issue547.cs
+++ b/EFCore.BulkExtensions.Tests/IncludeGraph/Issue547.cs
@@ -1,0 +1,126 @@
+﻿using EFCore.BulkExtensions.SqlAdapters;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests.IncludeGraph
+{
+    public class RootEntity
+    {
+        public int Id { get; set; }
+        public OwnedType Owned { get; set; }
+        public OwnedInSeparateTable OwnedInSeparateTable { get; set; }
+    }
+
+    public class OwnedType
+    {
+        public int? ChildId { get; set; }
+        public ChildEntity Child { get; set; }
+        public string Field1 { get; set; }
+    }
+
+    public class OwnedInSeparateTable
+    {
+        public string Flowers { get; set; }
+    }
+
+    public class ChildEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Issue547DbContext : DbContext
+    {
+        public Issue547DbContext([NotNullAttribute] DbContextOptions options) : base(options)
+        {
+        }
+
+        public DbSet<RootEntity> RootEntities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<RootEntity>(cfg =>
+            {
+                cfg.HasKey(y => y.Id);
+                cfg.OwnsOne(y => y.Owned, own =>
+                {
+                    own.HasOne(y => y.Child).WithMany().HasForeignKey(y => y.ChildId).IsRequired(false);
+                    own.Property(y => y.Field1).HasMaxLength(50);
+                });
+
+                cfg.OwnsOne(y => y.OwnedInSeparateTable, own =>
+                {
+                    own.ToTable(nameof(OwnedInSeparateTable));
+                });
+            });
+
+            modelBuilder.Entity<ChildEntity>(cfg =>
+            {
+                cfg.Property(y => y.Id).ValueGeneratedNever();
+                cfg.Property(y => y.Name);
+            });
+        }
+    }
+
+    public class Issue547
+    {
+        [Theory]
+        [InlineData(DbServer.SqlServer)]
+        public async Task Test(DbServer dbServer)
+        {
+            ContextUtil.DbServer = dbServer;
+
+            using var db = new Issue547DbContext(ContextUtil.GetOptions<Issue547DbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_Issue547"));
+            await db.Database.EnsureCreatedAsync();
+
+
+            var tranches = new List<RootEntity>
+            {
+                new RootEntity {
+                    Id = 1,
+                    Owned = new OwnedType
+                    {
+                        Field1 = "F1",
+                        ChildId = 1388,
+                        Child = new ChildEntity { Id = 1388, Name = "F1C1" }
+                    },
+                    OwnedInSeparateTable = new OwnedInSeparateTable
+                    {
+                        Flowers = "Roses"
+                    }
+                },
+                new RootEntity {
+                    Id = 2,
+                    Owned = new OwnedType
+                    {
+                        Field1 = "F2",
+                        ChildId = 1234,
+                        Child = new ChildEntity { Id = 1234, Name = "F2C2" }
+                    },
+                    OwnedInSeparateTable = new OwnedInSeparateTable
+                    {
+                        Flowers = "Tulips"
+                    }
+                }
+            };
+
+            await db.BulkInsertOrUpdateAsync(tranches, new BulkConfig
+            {
+                IncludeGraph = true
+            });
+
+            foreach (var a in tranches)
+            {
+                Assert.True(a.Owned.ChildId.HasValue);
+            }
+        }
+    }
+}

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -56,10 +56,17 @@ namespace EFCore.BulkExtensions
 
                 foreach (var graphNodeGroup in graphNodesGroupedByType)
                 {
+                    var entityClrType = graphNodeGroup.Key;
+                    var entityType = context.Model.FindEntityType(entityClrType);
+
+                    if (OwnedTypeUtil.IsOwnedInSameTableAsOwner(entityType))
+                    {
+                        continue;
+                    }
+
                     // It is possible the object graph contains duplicate entities (by primary key) but the entities are different object instances in memory.
                     // This an happen when deserializing a nested JSON tree for example. So filter out the duplicates.
                     var entitiesToAction = GetUniqueEntities(context, graphNodeGroup.Select(y => y.Entity)).ToList();
-                    var entityClrType = graphNodeGroup.Key;
                     var tableInfo = TableInfo.CreateInstance(context, entityClrType, entitiesToAction, operationType, bulkConfig);
 
                     if (isAsync)

--- a/EFCore.BulkExtensions/GraphUtil.cs
+++ b/EFCore.BulkExtensions/GraphUtil.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace EFCore.BulkExtensions
 {
@@ -95,7 +96,11 @@ namespace EFCore.BulkExtensions
             // i.e WorkOrderSpare.Spare but the Spare entity does not have a Spare.WorkOrderSpares navigation property
             var nestedDependency = GetFlatGraph(dbContext, navigationValue, result);
 
-            if (navigation.IsOnDependent)
+            if (navigation.IsOnDependent
+
+                // A navigation for an OwnedType will be dependent on its owner the in efcore dependency hierarchy,
+                // but technically the Owner depends on the OwnedType if the OwnedType is part of its Owner's schema.
+                || OwnedTypeUtil.IsOwnedInSameTableAsOwner(navigation))
             {
                 graphDependency.DependsOn.Add((navigationValue, navigation));
                 nestedDependency.Dependents.Add((graphEntity, navigation.Inverse ?? navigation));

--- a/EFCore.BulkExtensions/OwnedTypeUtil.cs
+++ b/EFCore.BulkExtensions/OwnedTypeUtil.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EFCore.BulkExtensions
+{
+    public static class OwnedTypeUtil
+    {
+        public static bool IsOwnedInSameTableAsOwner(IEntityType owned)
+        {
+            var ownership = owned.FindOwnership();
+
+            if (ownership is null)
+                return false;
+
+            var owner = ownership.PrincipalEntityType;
+            var ownedTables = owned.GetTableMappings();
+
+            foreach (var ot in ownedTables)
+            {
+                var isSharingTable = ot.Table.EntityTypeMappings.Any(y => y.EntityType == owner);
+
+                if (isSharingTable == false)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsOwnedInSameTableAsOwner(INavigation navigation)
+        {
+            return IsOwnedInSameTableAsOwner(navigation.TargetEntityType);
+        }
+    }
+}

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -433,6 +433,7 @@ namespace EFCore.BulkExtensions
                                 {
                                     string columnName = ownedEntityPropertyNameColumnNameDict[ownedProperty.Name];
                                     PropertyColumnNamesDict.Add(ownedPropertyFullName, columnName);
+                                    PropertyColumnNamesCompareDict.Add(ownedPropertyFullName, columnName);
                                     PropertyColumnNamesUpdateDict.Add(ownedPropertyFullName, columnName);
                                     OutputPropertyColumnNamesDict.Add(ownedPropertyFullName, columnName);
                                 }

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -379,6 +379,10 @@ namespace EFCore.BulkExtensions
                         var property = navigationProperty.PropertyInfo;
                         FastPropertyDict.Add(property.Name, new FastProperty(property));
 
+                        // If the OwnedType is mapped to the separate table, don't try merge it into its owner
+                        if (OwnedTypeUtil.IsOwnedInSameTableAsOwner(navigationProperty) == false)
+                            continue;
+
                         Type navOwnedType = type.Assembly.GetType(property.PropertyType.FullName);
                         var ownedEntityType = context.Model.FindEntityType(property.PropertyType);
                         if (ownedEntityType == null) // when entity has more then one ownedType (e.g. Address HomeAddress, Address WorkAddress) or one ownedType is in multiple Entities like Audit is usually.


### PR DESCRIPTION
Resolves #547 
OwnedTypes mapped to a separate table is now supported generally
OwnedType's properties mapped into the owner's table are now available in the PropertyColumnNamesCompareDict, so that changes to owned types properties will be saved to the database when doing an update / merge
IncludeGraph - OwnedType's owner now considered dependent on the OwnedType despite EFCore relational model being the inverse for correct topological sorting
IncludeGraph - OwnedTypes mapped to owner's table will be skipped when bulk saving the object graph (as they are part of their owner's schema instead)