### PR TITLE
Use SQLitePCLRaw.bundle_e_sqlite3 instead of SQLitePCLRaw.bundle_winsqlite3

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="5.0.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="RT.Comb" Version="2.5.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
     <TargetFramework>net5.0</TargetFramework>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="RT.Comb" Version="2.5.0" />
-    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.0.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
So that the SQLite tests pass also on Linux and macOS

Otherwise it fails with a System.DllNotFoundException:
> Unable to load shared library 'winsqlite3' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(libwinsqlite3, 1): image not found