### PR TITLE
BatchUpdate Preserve Correct SqlParameter Type - Resolves Issue #596

### DIFF
--- a/EFCore.BulkExtensions.Tests/CompilerServicesPolyfill.cs
+++ b/EFCore.BulkExtensions.Tests/CompilerServicesPolyfill.cs
@@ -1,0 +1,8 @@
+﻿#if NET5_0
+#else
+/// Polyfill so we can use C# 9.0 record types
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}
+#endif

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -139,7 +139,7 @@ namespace EFCore.BulkExtensions.Tests
                 context.Parents.Where(parent => parent.ParentId < 5 && !string.IsNullOrEmpty(parent.Details.Notes))
                     .BatchUpdate(parent => new Parent { Description = parent.Details.Notes ?? "Fallback" });
 
-                var actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+                var actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
                 var expectedSql =
 @"UPDATE p SET  [p].[Description] = (
     SELECT COALESCE([p1].[Notes], N'Fallback')
@@ -154,7 +154,7 @@ WHERE ([p].[ParentId] < 5) AND ([p0].[Notes] IS NOT NULL AND (([p0].[Notes] <> N
                 context.Parents.Where(parent => parent.ParentId == 1)
                     .BatchUpdate(parent => new Parent { Value = parent.Children.Where(child => child.IsEnabled).Sum(child => child.Value) });
 
-                actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+                actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
                 expectedSql =
 @"UPDATE p SET  [p].[Value] = (
     SELECT SUM([c].[Value])
@@ -173,7 +173,7 @@ WHERE [p].[ParentId] = 1";
                         Value = newValue
                     });
 
-                actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+                actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
                 expectedSql =
 @"UPDATE p SET  [p].[Description] = (CONVERT(VARCHAR(100), (
     SELECT SUM([c].[Value])

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -63,7 +63,7 @@ namespace EFCore.BulkExtensions.Tests
             string oldPhoneNumber = "7756789999";
             string newPhoneNumber = "3606789999";
 
-            await testContext.Parents
+            _ = await testContext.Parents
                 .Where(parent => parent.PhoneNumber == oldPhoneNumber)
                 .BatchUpdateAsync(parent => new Parent { PhoneNumber = newPhoneNumber })
                 .ConfigureAwait(false);
@@ -75,7 +75,7 @@ namespace EFCore.BulkExtensions.Tests
             Assert.Equal(System.Data.DbType.AnsiString, oldPhoneNumberParameter.DbType);
             Assert.Equal(System.Data.SqlDbType.VarChar, oldPhoneNumberParameter.SqlDbType);
 
-            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "param_1");
+            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "@param_1");
             Assert.Equal(System.Data.DbType.AnsiString, newPhoneNumberParameter.DbType);
             Assert.Equal(System.Data.SqlDbType.VarChar, newPhoneNumberParameter.SqlDbType);
 

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -1,5 +1,6 @@
 ﻿using EFCore.BulkExtensions.SqlAdapters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,6 +50,41 @@ namespace EFCore.BulkExtensions.Tests
                     Assert.EndsWith(" TOP(1)", firstItem.Name);
                 }
             }
+        }
+
+        [Fact]
+        public async Task BatchUpdateAsync_correctly_specifies_AnsiString_type_on_the_sql_parameter()
+        {
+            var dbCommandInterceptor = new TestDbCommandInterceptor();
+            var interceptors = new[] { dbCommandInterceptor };
+
+            using var testContext = new TestContext(ContextUtil.GetOptions<TestContext>(DbServer.SqlServer, interceptors));
+
+            string oldPhoneNumber = "7756789999";
+            string newPhoneNumber = "3606789999";
+
+            await testContext.Parents
+                .Where(parent => parent.PhoneNumber == oldPhoneNumber)
+                .BatchUpdateAsync(parent => new Parent { PhoneNumber = newPhoneNumber })
+                .ConfigureAwait(false);
+
+            var executedCommand = dbCommandInterceptor.ExecutedNonQueryCommands.Last();
+            Assert.Equal(2, executedCommand.DbParameters.Count);
+
+            var oldPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "@__oldPhoneNumber_0");
+            Assert.Equal(System.Data.DbType.AnsiString, oldPhoneNumberParameter.DbType);
+            Assert.Equal(System.Data.SqlDbType.VarChar, oldPhoneNumberParameter.SqlDbType);
+
+            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "param_1");
+            Assert.Equal(System.Data.DbType.AnsiString, newPhoneNumberParameter.DbType);
+            Assert.Equal(System.Data.SqlDbType.VarChar, newPhoneNumberParameter.SqlDbType);
+
+            var expectedSql =
+@"UPDATE p SET  [p].[PhoneNumber] = @param_1 
+FROM [Parent] AS [p]
+WHERE [p].[PhoneNumber] = @__oldPhoneNumber_0";
+
+            Assert.Equal(expectedSql.Replace("\r\n", "\n"), executedCommand.Sql.Replace("\r\n", "\n"));
         }
 
         internal async Task RunDeleteAllAsync(DbServer dbServer)

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -89,6 +89,9 @@ namespace EFCore.BulkExtensions.Tests
 
             modelBuilder.Entity<Setting>().Property(e => e.Settings).HasConversion<string>();
 
+            modelBuilder.Entity<Parent>().Property(parent => parent.PhoneNumber)
+                .HasColumnType("varchar(12)").HasMaxLength(12).HasField("_phoneNumber").IsRequired();
+
             // [Timestamp] alternative:
             //modelBuilder.Entity<Document>().Property(x => x.RowVersion).HasColumnType("timestamp").ValueGeneratedOnAddOrUpdate().HasConversion(new NumberToBytesConverter<ulong>()).IsConcurrencyToken();
 
@@ -98,17 +101,23 @@ namespace EFCore.BulkExtensions.Tests
 
     public static class ContextUtil
     {
+        // TODO: Pass DbService through all the GetOptions methods as a parameter and eliminate this property so the automated tests
+        // are thread safe
         public static DbServer DbServer { get; set; }
 
         public static DbContextOptions GetOptions(IInterceptor dbInterceptor) => GetOptions(new[] { dbInterceptor });
         public static DbContextOptions GetOptions(IEnumerable<IInterceptor> dbInterceptors = null) => GetOptions<TestContext>(dbInterceptors);
 
         public static DbContextOptions GetOptions<TDbContext>(IEnumerable<IInterceptor> dbInterceptors = null, string databaseName = nameof(EFCoreBulkTest))
-            where TDbContext: DbContext
+            where TDbContext : DbContext
+            => GetOptions<TDbContext>(ContextUtil.DbServer, dbInterceptors, databaseName);
+
+        public static DbContextOptions GetOptions<TDbContext>(DbServer dbServerType, IEnumerable<IInterceptor> dbInterceptors = null, string databaseName = nameof(EFCoreBulkTest))
+            where TDbContext : DbContext
         {
             var optionsBuilder = new DbContextOptionsBuilder<TDbContext>();
 
-            if (DbServer == DbServer.SqlServer)
+            if (dbServerType == DbServer.SqlServer)
             {
                 var connectionString = GetSqlServerConnectionString(databaseName);
 
@@ -118,7 +127,7 @@ namespace EFCore.BulkExtensions.Tests
                 //optionsBuilder.UseSqlServer(connectionString); // Can NOT Test with UseInMemoryDb (Exception: Relational-specific methods can only be used when the context is using a relational)
                 optionsBuilder.UseSqlServer(connectionString, opt => opt.UseNetTopologySuite()); // NetTopologySuite for Geometry / Geometry types
             }
-            else if (DbServer == DbServer.Sqlite)
+            else if (dbServerType == DbServer.Sqlite)
             {
                 string connectionString = GetSqliteConnectionString(databaseName);
                 optionsBuilder.UseSqlite(connectionString);
@@ -129,7 +138,7 @@ namespace EFCore.BulkExtensions.Tests
             }
             else
             {
-                throw new NotSupportedException($"Database {DbServer} is not supported. Only SQL Server and SQLite are Currently supported.");
+                throw new NotSupportedException($"Database {dbServerType} is not supported. Only SQL Server and SQLite are Currently supported.");
             }
 
             if (dbInterceptors?.Any() == true)
@@ -410,6 +419,10 @@ namespace EFCore.BulkExtensions.Tests
         public string Description { get; set; }
         public virtual ParentDetail Details { get; set; }
         public int ParentId { get; set; }
+
+        private string _phoneNumber;
+        public string PhoneNumber { get => _phoneNumber; set => _phoneNumber = value; }
+
         public decimal Value { get; set; }
     }
 

--- a/EFCore.BulkExtensions.Tests/TestDbCommandInterceptor.cs
+++ b/EFCore.BulkExtensions.Tests/TestDbCommandInterceptor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -8,17 +9,39 @@ namespace EFCore.BulkExtensions.Tests
 {
     public class TestDbCommandInterceptor : DbCommandInterceptor
     {
-        public List<string> AboutToBeExecutedCommands { get; } = new List<string>();
+        /// <summary>
+        /// Information about an intercepted <see cref="System.Data.Common.DbCommand"/>
+        /// </summary>
+        public record DbCommandInformation(IReadOnlyList<DbParameter> DbParameters, string Sql);
 
-        public List<string> ExecutedNonQueryCommands { get; } = new List<string>();
-        public List<string> ExecutedReaderCommands { get; } = new List<string>();
-        public List<string> ExecutedScalarCommands { get; } = new List<string>();
+        public List<DbCommandInformation> AboutToBeExecutedCommands { get; } = new List<DbCommandInformation>();
+
+        public List<DbCommandInformation> ExecutedNonQueryCommands { get; } = new List<DbCommandInformation>();
+        public List<DbCommandInformation> ExecutedReaderCommands { get; } = new List<DbCommandInformation>();
+        public List<DbCommandInformation> ExecutedScalarCommands { get; } = new List<DbCommandInformation>();
+
+        protected DbCommandInformation BuildCommandInformation(DbCommand dbCommand)
+        {
+            _ = dbCommand ?? throw new ArgumentNullException(nameof(dbCommand));
+
+            var dbParameters = new List<DbParameter>();
+            if (dbCommand.Parameters != null)
+            {
+                foreach (DbParameter parameter in dbCommand.Parameters)
+                    dbParameters.Add(parameter);
+            }
+
+            return new DbCommandInformation(dbParameters, dbCommand.CommandText);
+        }
 
         public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
         {
             if (command?.CommandText != null)
             {
-                ExecutedNonQueryCommands.Add(command.CommandText);
+                lock (ExecutedNonQueryCommands)
+                {
+                    ExecutedNonQueryCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecuted(command, eventData, result);
@@ -28,7 +51,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedNonQueryCommands.Add(command.CommandText);
+                lock (ExecutedNonQueryCommands)
+                {
+                    ExecutedNonQueryCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
@@ -38,7 +64,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecuting(command, eventData, result);
@@ -48,7 +77,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
@@ -58,7 +90,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedReaderCommands.Add(command.CommandText);
+                lock (ExecutedReaderCommands)
+                {
+                    ExecutedReaderCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecuted(command, eventData, result);
@@ -68,7 +103,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedReaderCommands.Add(command.CommandText);
+                lock (ExecutedReaderCommands)
+                {
+                    ExecutedReaderCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
@@ -78,7 +116,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecuting(command, eventData, result);
@@ -88,7 +129,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
@@ -98,7 +142,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedScalarCommands.Add(command.CommandText);
+                lock (ExecutedScalarCommands)
+                {
+                    ExecutedScalarCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecuted(command, eventData, result);
@@ -108,7 +155,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedScalarCommands.Add(command.CommandText);
+                lock (ExecutedScalarCommands)
+                {
+                    ExecutedScalarCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
@@ -118,7 +168,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecuting(command, eventData, result);
@@ -128,7 +181,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -16,6 +16,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyVersion>3.6.1.0</AssemblyVersion>
     <FileVersion>3.6.1.0</FileVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.BulkExtensions/SqlClientHelper.cs
+++ b/EFCore.BulkExtensions/SqlClientHelper.cs
@@ -63,6 +63,18 @@ namespace EFCore.BulkExtensions
             // copy properties from original parameter to copy
             newParameter.ParameterName = parameter.ParameterName;
             newParameter.Value = parameter.Value;
+            newParameter.DbType = parameter.DbType;
+
+            if (parameter is Microsoft.Data.SqlClient.SqlParameter microsoftSqlParameter
+                && newParameter is System.Data.SqlClient.SqlParameter newSystemSqlParameter)
+            {
+                newSystemSqlParameter.SqlDbType = microsoftSqlParameter.SqlDbType;
+            }
+            else if(parameter is System.Data.SqlClient.SqlParameter systemSqlParameter
+                && newParameter is Microsoft.Data.SqlClient.SqlParameter newMicrosoftSqlParameter)
+            {
+                newMicrosoftSqlParameter.SqlDbType = systemSqlParameter.SqlDbType;
+            }
 
             return newParameter;
         }

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -49,6 +49,7 @@ namespace EFCore.BulkExtensions
         public Dictionary<string, string> OutputPropertyColumnNamesDict { get; set; } = new Dictionary<string, string>();
         public Dictionary<string, string> PropertyColumnNamesDict { get; set; } = new Dictionary<string, string>();
         public Dictionary<string, string> ColumnNamesTypesDict { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, IProperty> ColumnToPropertyDictionary { get; set; } = new Dictionary<string, IProperty>();
         public Dictionary<string, string> PropertyColumnNamesCompareDict { get; set; } = new Dictionary<string, string>();
         public Dictionary<string, string> PropertyColumnNamesUpdateDict { get; set; } = new Dictionary<string, string>();
         public Dictionary<string, FastProperty> FastPropertyDict { get; set; } = new Dictionary<string, FastProperty>();
@@ -133,9 +134,14 @@ namespace EFCore.BulkExtensions
             PrimaryKeysPropertyColumnNameDict = AreSpecifiedUpdateByProperties ? BulkConfig.UpdateByProperties.ToDictionary(a => a, b => b)
                                                                                : (primaryKeys ?? new Dictionary<string, string>());
 
-            var allProperties = entityType.GetProperties().AsEnumerable();
+            var allProperties = entityType.GetProperties();
 
-            ColumnNamesTypesDict = allProperties.ToDictionary(a => a.GetColumnName(), a => a.GetColumnType());
+            foreach (var entityProperty in allProperties)
+            {
+                var columnName = entityProperty.GetColumnName();
+                ColumnNamesTypesDict.Add(columnName, entityProperty.GetColumnType());
+                ColumnToPropertyDictionary.Add(columnName, entityProperty);
+            }
 
             // load all derived type properties
             if (entityType.IsAbstract())


### PR DESCRIPTION
**Fix For Issue #596**
* Added a new `BatchUpdateAsync_correctly_specifies_AnsiString_type_on_the_sql_parameter` test case that verifies the sql parameter type matches the expected `DbType.AnsiString` / `SqlDbType.VarChar` in both the `.Where(expresion)` and the `.BatchUpdateAsync(model => expression)`.
* Updated the `BatchUtil` logic that builds the sql parameters for the `BatchUpdate` / `BatchUpdateAsync` methods. The logic now first attempt to find and use the entity framework `RelationalTypeMapping.CreateParameter(..)` call for the column/property before falling back on direct instantiation of a db parameter.