### PR TITLE
Fix For Issue 596 - Correct BatchUpdate SqlParameter Type

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>    
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTest.cs
@@ -137,7 +137,7 @@ namespace EFCore.BulkExtensions.Tests
             context.Parents.Where(parent => parent.ParentId < 5 && !string.IsNullOrEmpty(parent.Details.Notes))
                 .BatchUpdate(parent => new Parent { Description = parent.Details.Notes ?? "Fallback" });
 
-            var actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+            var actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
             var expectedSql =
 @"UPDATE p SET  [p].[Description] = (
     SELECT COALESCE([p1].[Notes], N'Fallback')
@@ -152,7 +152,7 @@ WHERE ([p].[ParentId] < 5) AND ([p0].[Notes] IS NOT NULL AND (([p0].[Notes] <> N
             context.Parents.Where(parent => parent.ParentId == 1)
                 .BatchUpdate(parent => new Parent { Value = parent.Children.Where(child => child.IsEnabled).Sum(child => child.Value) });
 
-            actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+            actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
             expectedSql =
 @"UPDATE p SET  [p].[Value] = (
     SELECT COALESCE(SUM([c].[Value]), 0.0)
@@ -172,7 +172,7 @@ WHERE [p].[ParentId] = 1";
                     Value = newValue
                 });
 
-            actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault();
+            actualSqlExecuted = testDbCommandInterceptor.ExecutedNonQueryCommands?.LastOrDefault().Sql;
             expectedSql =
 @"UPDATE p SET  [p].[Description] = (CONVERT(VARCHAR(100), (
     SELECT COALESCE(SUM([c].[Value]), 0.0)

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -63,7 +63,7 @@ namespace EFCore.BulkExtensions.Tests
             string oldPhoneNumber = "7756789999";
             string newPhoneNumber = "3606789999";
 
-            await testContext.Parents
+            _ = await testContext.Parents
                 .Where(parent => parent.PhoneNumber == oldPhoneNumber)
                 .BatchUpdateAsync(parent => new Parent { PhoneNumber = newPhoneNumber })
                 .ConfigureAwait(false);
@@ -75,7 +75,7 @@ namespace EFCore.BulkExtensions.Tests
             Assert.Equal(System.Data.DbType.AnsiString, oldPhoneNumberParameter.DbType);
             Assert.Equal(System.Data.SqlDbType.VarChar, oldPhoneNumberParameter.SqlDbType);
 
-            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "param_1");
+            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "@param_1");
             Assert.Equal(System.Data.DbType.AnsiString, newPhoneNumberParameter.DbType);
             Assert.Equal(System.Data.SqlDbType.VarChar, newPhoneNumberParameter.SqlDbType);
 

--- a/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBatchTestAsync.cs
@@ -1,5 +1,6 @@
 ﻿using EFCore.BulkExtensions.SqlAdapters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,6 +50,41 @@ namespace EFCore.BulkExtensions.Tests
             {
                 Assert.EndsWith(" TOP(1)", firstItem.Name);
             }
+        }
+
+        [Fact]
+        public async Task BatchUpdateAsync_correctly_specifies_AnsiString_type_on_the_sql_parameter()
+        {
+            var dbCommandInterceptor = new TestDbCommandInterceptor();
+            var interceptors = new[] { dbCommandInterceptor };
+
+            using var testContext = new TestContext(ContextUtil.GetOptions<TestContext>(DbServer.SqlServer, interceptors));
+
+            string oldPhoneNumber = "7756789999";
+            string newPhoneNumber = "3606789999";
+
+            await testContext.Parents
+                .Where(parent => parent.PhoneNumber == oldPhoneNumber)
+                .BatchUpdateAsync(parent => new Parent { PhoneNumber = newPhoneNumber })
+                .ConfigureAwait(false);
+
+            var executedCommand = dbCommandInterceptor.ExecutedNonQueryCommands.Last();
+            Assert.Equal(2, executedCommand.DbParameters.Count);
+
+            var oldPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "@__oldPhoneNumber_0");
+            Assert.Equal(System.Data.DbType.AnsiString, oldPhoneNumberParameter.DbType);
+            Assert.Equal(System.Data.SqlDbType.VarChar, oldPhoneNumberParameter.SqlDbType);
+
+            var newPhoneNumberParameter = (Microsoft.Data.SqlClient.SqlParameter)executedCommand.DbParameters.Single(param => param.ParameterName == "param_1");
+            Assert.Equal(System.Data.DbType.AnsiString, newPhoneNumberParameter.DbType);
+            Assert.Equal(System.Data.SqlDbType.VarChar, newPhoneNumberParameter.SqlDbType);
+
+            var expectedSql =
+@"UPDATE p SET  [p].[PhoneNumber] = @param_1 
+FROM [Parent] AS [p]
+WHERE [p].[PhoneNumber] = @__oldPhoneNumber_0";
+
+            Assert.Equal(expectedSql.Replace("\r\n", "\n"), executedCommand.Sql.Replace("\r\n", "\n"));
         }
 
         internal async Task RunDeleteAllAsync(DbServer dbServer)

--- a/EFCore.BulkExtensions.Tests/TestDbCommandInterceptor.cs
+++ b/EFCore.BulkExtensions.Tests/TestDbCommandInterceptor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -8,17 +9,39 @@ namespace EFCore.BulkExtensions.Tests
 {
     public class TestDbCommandInterceptor : DbCommandInterceptor
     {
-        public List<string> AboutToBeExecutedCommands { get; } = new List<string>();
+        /// <summary>
+        /// Information about an intercepted <see cref="System.Data.Common.DbCommand"/>
+        /// </summary>
+        public record DbCommandInformation(IReadOnlyList<DbParameter> DbParameters, string Sql);
 
-        public List<string> ExecutedNonQueryCommands { get; } = new List<string>();
-        public List<string> ExecutedReaderCommands { get; } = new List<string>();
-        public List<string> ExecutedScalarCommands { get; } = new List<string>();
+        public List<DbCommandInformation> AboutToBeExecutedCommands { get; } = new List<DbCommandInformation>();
+
+        public List<DbCommandInformation> ExecutedNonQueryCommands { get; } = new List<DbCommandInformation>();
+        public List<DbCommandInformation> ExecutedReaderCommands { get; } = new List<DbCommandInformation>();
+        public List<DbCommandInformation> ExecutedScalarCommands { get; } = new List<DbCommandInformation>();
+
+        protected DbCommandInformation BuildCommandInformation(DbCommand dbCommand)
+        {
+            _ = dbCommand ?? throw new ArgumentNullException(nameof(dbCommand));
+
+            var dbParameters = new List<DbParameter>();
+            if (dbCommand.Parameters != null)
+            {
+                foreach (DbParameter parameter in dbCommand.Parameters)
+                    dbParameters.Add(parameter);
+            }
+
+            return new DbCommandInformation(dbParameters, dbCommand.CommandText);
+        }
 
         public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
         {
             if (command?.CommandText != null)
             {
-                ExecutedNonQueryCommands.Add(command.CommandText);
+                lock (ExecutedNonQueryCommands)
+                {
+                    ExecutedNonQueryCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecuted(command, eventData, result);
@@ -28,7 +51,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedNonQueryCommands.Add(command.CommandText);
+                lock (ExecutedNonQueryCommands)
+                {
+                    ExecutedNonQueryCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
@@ -38,7 +64,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecuting(command, eventData, result);
@@ -48,7 +77,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
@@ -58,7 +90,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedReaderCommands.Add(command.CommandText);
+                lock (ExecutedReaderCommands)
+                {
+                    ExecutedReaderCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecuted(command, eventData, result);
@@ -68,7 +103,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedReaderCommands.Add(command.CommandText);
+                lock (ExecutedReaderCommands)
+                {
+                    ExecutedReaderCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
@@ -78,7 +116,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecuting(command, eventData, result);
@@ -88,7 +129,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
@@ -98,7 +142,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedScalarCommands.Add(command.CommandText);
+                lock (ExecutedScalarCommands)
+                {
+                    ExecutedScalarCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecuted(command, eventData, result);
@@ -108,7 +155,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                ExecutedScalarCommands.Add(command.CommandText);
+                lock (ExecutedScalarCommands)
+                {
+                    ExecutedScalarCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
@@ -118,7 +168,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecuting(command, eventData, result);
@@ -128,7 +181,10 @@ namespace EFCore.BulkExtensions.Tests
         {
             if (command?.CommandText != null)
             {
-                AboutToBeExecutedCommands.Add(command.CommandText);
+                lock (AboutToBeExecutedCommands)
+                {
+                    AboutToBeExecutedCommands.Add(BuildCommandInformation(command));
+                }
             }
 
             return base.ScalarExecutingAsync(command, eventData, result, cancellationToken);

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -21,6 +21,7 @@
     <AssemblyOriginatorKeyFile>Keys\EFCore.BulkExtensions.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix For Issue #596 

* Added a new `BatchUpdateAsync_correctly_specifies_AnsiString_type_on_the_sql_parameter` test case that verifies the sql parameter type matches the expected `DbType.AnsiString` / `SqlDbType.VarChar` in both the `.Where(expresion)` and the `.BatchUpdateAsync(model => expression)`.

* Updated the `BatchUtil` logic that builds the sql parameters for the `BatchUpdate` / `BatchUpdateAsync` methods. The logic now first attempt to find and use the entity framework `RelationalTypeMapping.CreateParameter(..)` call for the column/property before falling back on direct instantiation of a db parameter.