### PR TITLE
Fix Postgres BulkInsert CLR type matching

### DIFF
--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -8,6 +8,8 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
+using NpgsqlTypes;
 
 namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql
 {
@@ -39,29 +41,31 @@ namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql
             {
                 string sqlCopy = SqlQueryBuilderPostgreSql.InsertIntoTable(tableInfo, tableInfo.InsertToTempTable ? OperationType.InsertOrUpdate : OperationType.Insert);
 
-                using (var writer = connection.BeginBinaryImport(sqlCopy))
-                {
-                    var uniquColumnName = tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList().FirstOrDefault();
-                    var propertiesColumnDict = (tableInfo.InsertToTempTable && tableInfo.IdentityColumnName == uniquColumnName)
-                                               ? tableInfo.PropertyColumnNamesDict
-                                               : tableInfo.PropertyColumnNamesDict.Where(a => a.Value != tableInfo.IdentityColumnName);
-                    var propertiesNames = propertiesColumnDict.Select(a => a.Key).ToList();
+                using var writer = connection.BeginBinaryImport(sqlCopy);
+                var uniqueColumnName = tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList().FirstOrDefault();
+                var propertiesColumnDict = (tableInfo.InsertToTempTable && tableInfo.IdentityColumnName == uniqueColumnName)
+                    ? tableInfo.PropertyColumnNamesDict
+                    : tableInfo.PropertyColumnNamesDict.Where(a => a.Value != tableInfo.IdentityColumnName);
+                var propertiesNames = propertiesColumnDict.Select(a => a.Key).ToList();
 
-                    foreach (var entity in entities)
+                foreach (var entity in entities)
+                {
+                    writer.StartRow();
+                    foreach (var propertyName in propertiesNames)
                     {
-                        writer.StartRow();
-                        foreach (var propertyName in propertiesNames)
+                        var propertyValue = tableInfo.FastPropertyDict.ContainsKey(propertyName) ? tableInfo.FastPropertyDict[propertyName].Get(entity) : null;
+                        var propertyColumnName = tableInfo.PropertyColumnNamesDict.ContainsKey(propertyName) ? tableInfo.PropertyColumnNamesDict[propertyName] : string.Empty;
+                        if (tableInfo.ColumnNamesTypesDict.ContainsKey(propertyColumnName))
                         {
-                            var propertyValue = tableInfo.FastPropertyDict.ContainsKey(propertyName) ? tableInfo.FastPropertyDict[propertyName].Get(entity) : null;
-                            //var isDecimalType = tableInfo.FastPropertyDict[propertyName].Property.PropertyType == typeof(decimal);
-                            //if (isDecimalType)
-                            //    writer.Write(propertyValue, NpgsqlDbType.Numeric);
-                            //else
-                                writer.Write(propertyValue);
+                            writer.Write(propertyValue, tableInfo.ColumnNamesTypesDict[propertyColumnName]);
+                        }
+                        else
+                        {
+                            writer.Write(propertyValue);
                         }
                     }
-                    writer.Complete();
                 }
+                writer.Complete();
             }
             finally
             {


### PR DESCRIPTION
Instead of `Write`'ing just value also provide column type name when
available. In this case correct column type will be used for CLR
types that are not natively supported or mapped. While this pretty
much fixes the issue #67 (specifically https://github.com/borisdj/EFCore.BulkExtensions/issues/67#issuecomment-982876139 ) , relying on final column
type can lead to issues when assumed type handler doesn't match the actual type.
For example `uint32` has pg type `bigint`, but default handler for this
type is `Int64Handler` which doesn't handle `uint32`.

But regardless of that, this should fix majority of issues with CLR type mapping.

Also I am not entirely sure whats the pattern with using non-async variants inside
async functions. Especially when nested non-async variants call async variants
with `GetAwaiter().GetResult()`. Seems pretty wasteful and not very performant.
I noticed somewhat similar pattern in Npgsql code, so maybe it makes some sense.
But regardless of that, I found that when using non-async variants in `BulkInsert`,
running 4 tasks inserting 1 million entities each (50k batches), frequently only single
task is started at a time. Changing to async in b36d013dee8d0a9fe50a696f6fd477fdd77a8759 alleviates this and
shows each task starting around same time.