### PR TITLE
Remove timestamptz type modification

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
     <PackageReference Include="RT.Comb" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -33,6 +33,7 @@ namespace EFCore.BulkExtensions.Tests
             context.Database.ExecuteSqlRaw($@"ALTER SEQUENCE ""{nameof(Item)}_{nameof(Item.ItemId)}_seq"" RESTART WITH 1");
 
             var currentTime = DateTime.Now;
+            var currentTimeOffset = DateTimeOffset.UtcNow;
 
             var entities = new List<Item>();
             for (int i = 1; i <= 2; i++)
@@ -44,7 +45,8 @@ namespace EFCore.BulkExtensions.Tests
                     Description = "info " + i,
                     Quantity = i,
                     Price = 0.1m * i,
-                    TimeUpdated = currentTime
+                    TimeUpdated = currentTime,
+                    TimeUpdatedTz = currentTimeOffset
                 };
                 entities.Add(entity);
             }
@@ -59,7 +61,8 @@ namespace EFCore.BulkExtensions.Tests
                     Description = "UPDATE " + i,
                     Quantity = i,
                     Price = 0.1m * i,
-                    TimeUpdated = currentTime
+                    TimeUpdated = currentTime,
+                    TimeUpdatedTz = currentTimeOffset
                 };
                 entities2.Add(entity);
             }
@@ -74,7 +77,8 @@ namespace EFCore.BulkExtensions.Tests
                     Description = "CHANGE " + i,
                     Quantity = i,
                     Price = 0.1m * i,
-                    TimeUpdated = currentTime
+                    TimeUpdated = currentTime,
+                    TimeUpdatedTz = currentTimeOffset
                 };
                 entities3.Add(entity);
             }

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -114,6 +114,7 @@ namespace EFCore.BulkExtensions.Tests
                     Quantity = i % 10,
                     Price = i / (i % 5 + 1),
                     TimeUpdated = DateTime.Now,
+                    TimeUpdatedTz = DateTimeOffset.UtcNow,
                     ItemHistories = new List<ItemHistory>()
                 };
 
@@ -207,6 +208,7 @@ namespace EFCore.BulkExtensions.Tests
             {
                 var entities = new List<Item>();
                 var dateTimeNow = DateTime.Now;
+                var dateTimeOffsetNow = DateTimeOffset.UtcNow;
                 for (int i = 2; i <= EntitiesNumber; i += 2)
                 {
                     entities.Add(new Item
@@ -216,7 +218,8 @@ namespace EFCore.BulkExtensions.Tests
                         Description = "info",
                         Quantity = i,
                         Price = i / (i % 5 + 1),
-                        TimeUpdated = dateTimeNow
+                        TimeUpdated = dateTimeNow,
+                        TimeUpdatedTz = dateTimeOffsetNow,
                     });
                 }
                 if (isBulk)
@@ -252,6 +255,7 @@ namespace EFCore.BulkExtensions.Tests
 
             var entities = new List<Item>();
             var dateTimeNow = DateTime.Now;
+            var dateTimeOffsetNow = DateTimeOffset.UtcNow;
             for (int i = 2; i <= EntitiesNumber; i += 2)
             {
                 entities.Add(new Item
@@ -261,7 +265,8 @@ namespace EFCore.BulkExtensions.Tests
                     Description = "info",
                     Quantity = i,
                     Price = i / (i % 5 + 1),
-                    TimeUpdated = dateTimeNow
+                    TimeUpdated = dateTimeNow,
+                    TimeUpdatedTz = dateTimeOffsetNow,
                 });
             }
 

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -122,6 +122,7 @@ namespace EFCore.BulkExtensions.Tests
             if (Database.IsNpgsql())
             {
                 modelBuilder.Entity<Event>().Property(p => p.TimeCreated).HasColumnType("timestamp");
+                modelBuilder.Entity<Item>().Property(p => p.TimeUpdated).HasColumnType("timestamp without time zone");
             }
 
             //modelBuilder.Entity<Modul>(buildAction => { buildAction.HasNoKey(); });
@@ -259,6 +260,8 @@ namespace EFCore.BulkExtensions.Tests
 
         //[Column(TypeName = (nameof(DateTime)))] // Column to be of DbType 'datetime' instead of default 'datetime2'
         public DateTime TimeUpdated { get; set; }
+        
+        public DateTimeOffset TimeUpdatedTz { get; set; }
 
         public ICollection<ItemHistory> ItemHistories { get; set; }
     }

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.0" />
     <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -8,8 +8,6 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Storage;
-using NpgsqlTypes;
 
 namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql
 {
@@ -68,7 +66,6 @@ namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql
                         if (tableInfo.ColumnNamesTypesDict.ContainsKey(propertyColumnName))
                         {
                             var columnType = tableInfo.ColumnNamesTypesDict[propertyColumnName];
-                            columnType = columnType.Replace(" with time zone", ""); // "timestamp with time zone" -> "timestamp" (otherwise throws: Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone', only UTC is supported.')
                             if (isAsync)
                             {
                                 await writer.WriteAsync(propertyValue, columnType, cancellationToken).ConfigureAwait(false);
@@ -99,7 +96,6 @@ namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql
                 {
                     writer.Complete();
                 }
-
             }
             finally
             {

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -216,7 +216,7 @@ namespace EFCore.BulkExtensions
             if (BulkConfig.IgnoreRowVersion)
                 timeStampProperties = new List<IProperty>();
             else
-                timeStampProperties = allProperties.Where(a => (a.IsConcurrencyToken && a.ValueGenerated == ValueGenerated.OnAddOrUpdate) || a.GetColumnType() == timestampDbTypeName);
+                timeStampProperties = allProperties.Where(a => (a.IsConcurrencyToken && a.ValueGenerated == ValueGenerated.OnAddOrUpdate) || a.GetColumnType() == timestampDbTypeName); // this is incorrect assumption and voids normal columns with timestamp type in Postgres
             TimeStampColumnName = timeStampProperties.FirstOrDefault()?.GetColumnName(ObjectIdentifier); // can be only One
             TimeStampPropertyName = timeStampProperties.FirstOrDefault()?.Name; // can be only One
             var allPropertiesExceptTimeStamp = allProperties.Except(timeStampProperties);


### PR DESCRIPTION
Reverts change done in https://github.com/borisdj/EFCore.BulkExtensions/commit/e70de346179c3c425e3f765b11071b02743c69cc that modified `timestamp with time zone` to `timestamp`.
This shouldnt be done as the timestamp change is intentional and was introduced in Npgsql 6 to set some constraints on how `DateTime` is used/communicated with Postgres.
See:
- https://www.npgsql.org/doc/release-notes/6.0.html#timestamp-rationalization-and-improvements
- https://www.roji.org/postgresql-dotnet-timestamp-mapping

Error in the comment is correct and should have been corrected in code rather than in the library code, as it notifies user that incorrect assumptions are made regarding date time usage. It also breaks code that uses `DateTimeOffset` for `timestamp with time zone` as Npgsql picks `TimestampHandler` for `timestamp` column field which is not supported by that handler https://github.com/npgsql/npgsql/blob/a1d366c5692cc00a5edc1ec5bc9090952c7a63e7/src/Npgsql/Internal/TypeHandlers/DateTimeHandlers/TimestampHandler.cs#L20 .

Updated tests to have a column `timestamp without time zone` that can be populated with standard `DateTime` (with kind `Local`) and another column with `DateTimeOffset` that uses `timestamp with time zone`.

Test run locally (2 failed due to: `Microsoft.Data.SqlClient.SqlException : Common Language Runtime(CLR) is not enabled on this instance` as I can't get SQL Server with CLR running):
```
Failed!  - Failed:     2, Passed:    62, Skipped:     0, Total:    64,
```

Also while debugging I found a piece of code that seems to have incorrect assumptions on `timestamp` fields which assumes that they are used for versioning/concurrency check. `timestamp` is alias for type `timestamp without time zone` in postgres, but if `HasColumnType` is set to `timestamp` populated `TableInfo` incorrectly assumes that it is used for version/concurrency check.