### PR TITLE
Safety checks for Get and Set methods.

### DIFF
--- a/EFCore.BulkExtensions/FastProperty.cs
+++ b/EFCore.BulkExtensions/FastProperty.cs
@@ -40,7 +40,13 @@ namespace EFCore.BulkExtensions
 
         public Action<object, object> SetDelegate;
 
-        public object Get(object instance) { return GetDelegate(instance); }
-        public void Set(object instance, object value) { SetDelegate(instance, value); }
+        public object Get(object instance) { return instance == default ? default : GetDelegate(instance); }
+        public void Set(object instance, object value)
+        {
+            if(value != default)
+            {
+                SetDelegate(instance, value);
+            }
+        }
     }
 }


### PR DESCRIPTION
Get method returns default object when instance is null. Set method checks to see if the value passed in is not default before it assignes it.