### PR TITLE
Added global function to return shadow property values

### DIFF
--- a/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
@@ -18,7 +18,7 @@ namespace EFCore.BulkExtensions.Tests.ShadowProperties
 
             using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties"));
 
-            db.BulkInsertOrUpdate(this.GetTestData(db).ToList(), new BulkConfig
+            db.BulkInsertOrUpdate(this.GetTestData(db, true, 10000).ToList(), new BulkConfig
             {
                 EnableShadowProperties = true
             });
@@ -30,14 +30,67 @@ namespace EFCore.BulkExtensions.Tests.ShadowProperties
             Assert.Equal(new DateTime(2021, 02, 14), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
         }
 
-        private IEnumerable<SpModel> GetTestData(DbContext db)
+        [Theory]
+        [InlineData(DbServer.SQLServer)]
+        [InlineData(DbServer.SQLite)]
+        public void BulkInsertOrUpdate_EntityWithShadowProperties_GlobalFunc_SavesToDatabase(DbServer dbServer)
         {
-            var one = new SpModel();
-            db.Entry(one).Property(SpModel.SpLong).CurrentValue = (long)10;
-            db.Entry(one).Property(SpModel.SpNullableLong).CurrentValue = null;
-            db.Entry(one).Property(SpModel.SpDateTime).CurrentValue = new DateTime(2021, 02, 14);
+            ContextUtil.DbServer = dbServer;
 
-            yield return one;
+            using var db = new SpDbContext(ContextUtil.GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties"));
+
+            var data = GetTestData(db, false, 10000);
+
+            db.BulkInsertOrUpdate(data.ToList(), new BulkConfig
+            {
+                EnableShadowProperties = true,
+                ShadowPropertyValue = (entity, property) =>
+                {
+
+                    if (property == SpModel.SpLong)
+                    {
+                        return 10;
+                    }
+                    else if (property == SpModel.SpNullableLong)
+                    {
+                        return null;
+                    }
+                    else if (property == SpModel.SpDateTime)
+                    {
+                        return new DateTime(2021, 02, 14);
+                    }
+
+                    return property;
+
+                }
+            });
+
+            var modelFromDb = db.SpModels.OrderByDescending(y => y.Id).First();
+            Assert.Equal((long)10, db.Entry(modelFromDb).Property(SpModel.SpLong).CurrentValue);
+            Assert.Null(db.Entry(modelFromDb).Property(SpModel.SpNullableLong).CurrentValue);
+
+            Assert.Equal(new DateTime(2021, 02, 14), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+        }
+
+        private IEnumerable<SpModel> GetTestData(DbContext db, bool useEf, int count)
+        {
+            var data = new List<SpModel>();
+
+            for (int i = 0; i < count; i++)
+            {
+                var one = new SpModel();
+
+                if (useEf)
+                {
+                    db.Entry(one).Property(SpModel.SpLong).CurrentValue = (long)10;
+                    db.Entry(one).Property(SpModel.SpNullableLong).CurrentValue = null;
+                    db.Entry(one).Property(SpModel.SpDateTime).CurrentValue = new DateTime(2021, 02, 14);
+                }
+
+                data.Add(one);
+            }
+
+            return data; 
         }
 
         public void Dispose()

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -170,6 +170,13 @@ namespace EFCore.BulkExtensions
         /// </summary>
         public bool EnableShadowProperties { get; set; }
 
+
+        /// <summary>
+        ///     Returns value for shadow properties, EnableShadowProperties = true
+        /// </summary>
+        public Func<object, string, object> ShadowPropertyValue { get; set; } 
+
+
         /// <summary>
         ///    Shadow columns used for Temporal table. Has defaults elements: 'PeriodStart' and 'PeriodEnd'. Can be changed if temporal columns have custom names.
         /// </summary>

--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -697,7 +697,17 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
                     {
                         var shadowProperty = entityPropertiesDict[shadowPropertyName];
                         var columnName = shadowPropertyColumnNamesDict[shadowPropertyName];
-                        var propertyValue = context.Entry(entity).Property(shadowPropertyName).CurrentValue;
+
+                        var propertyValue = default(object);
+
+                        if (tableInfo.BulkConfig.ShadowPropertyValue == null)
+                        {
+                            propertyValue = context.Entry(entity).Property(shadowPropertyName).CurrentValue;
+                        }
+                        else 
+                        {
+                            propertyValue = tableInfo.BulkConfig.ShadowPropertyValue(entity, shadowPropertyName);
+                        }
 
                         if (tableInfo.ConvertibleColumnConverterDict.ContainsKey(columnName))
                         {

--- a/EFCore.BulkExtensions/SQLAdapters/SQLite/SqLiteAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLite/SqLiteAdapter.cs
@@ -402,7 +402,16 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLite
                 {
                     if (tableInfo.BulkConfig.EnableShadowProperties)
                     {
-                        value = dbContext.Entry(entity).Property(propertyColumn.Key).CurrentValue; // Get the shadow property value
+                        if (tableInfo.BulkConfig.ShadowPropertyValue == null)
+                        {
+                            value = dbContext.Entry(entity).Property(propertyColumn.Key).CurrentValue; // Get the shadow property value
+                        }
+                        else
+                        {
+                            value = tableInfo.BulkConfig.ShadowPropertyValue(entity, propertyColumn.Key);
+                        }
+
+                        
                     }
                     else
                     {


### PR DESCRIPTION
Added an alternative method of supplying values for shadow properties.

In my use case, I only need to set IsDelete to false for soft deletes and discriminator columns.

Using the function will save memory as not needing to add the entity to the EF change tracking.