### PR TITLE
Ef core3.1 Dispose MemoryStream and BinaryWriter

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
@@ -34,6 +34,10 @@ namespace EFCore.BulkExtensions.Tests
             var connection = new SqlConnection(connectionString) as DbConnection;
             connection = new MyConnection(connection);
             builder.UseSqlServer(connection, opt => opt.UseNetTopologySuite());
+            builder.UseSqlServer(connection, conf =>
+            {
+                conf.UseHierarchyId();
+            });
             return builder.Options;
         }
 

--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -724,8 +724,8 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
 
                     if (propertyValue is HierarchyId hierarchyValue && isSqlServer)
                     {
-                        MemoryStream memStream = new MemoryStream();
-                        BinaryWriter binWriter = new BinaryWriter(memStream);
+                        using MemoryStream memStream = new MemoryStream();
+                        using BinaryWriter binWriter = new BinaryWriter(memStream);
                         hierarchyValue.Write(binWriter);
                         propertyValue = memStream.ToArray();
                     }


### PR DESCRIPTION
Corrections:
- added the disposing of the MemoryStream and BinaryWriter according to klemmchr suggestions.
- corrected the GetOptions for EFCoreBulkUnderlyingTest test to support HierachyId