### PR TITLE
InsertOrUpdateDelete Output optimization

### DIFF
--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -184,14 +184,18 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
                         context.Database.ExecuteSqlRaw(sqlAddColumn);
                     }
                 }
-                var sqlAlterTableColumnsToNullable = SqlQueryBuilder.AlterTableColumnsToNullable(tableInfo.FullTempOutputTableName, tableInfo);
-                if (isAsync)
+
+                if (operationType == OperationType.InsertOrUpdateDelete)
                 {
-                    await context.Database.ExecuteSqlRawAsync(sqlAlterTableColumnsToNullable, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    context.Database.ExecuteSqlRaw(sqlAlterTableColumnsToNullable);
+                    var sqlAlterTableColumnsToNullable = SqlQueryBuilder.AlterTableColumnsToNullable(tableInfo.FullTempOutputTableName, tableInfo);
+                    if (isAsync)
+                    {
+                        await context.Database.ExecuteSqlRawAsync(sqlAlterTableColumnsToNullable, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        context.Database.ExecuteSqlRaw(sqlAlterTableColumnsToNullable);
+                    }
                 }
             }
 


### PR DESCRIPTION
Issue: https://github.com/borisdj/EFCore.BulkExtensions/issues/723

Adding `InsertOrUpdateDelete` output optimization commit into the V5 version of the branch. Original commit here for reference: https://github.com/borisdj/EFCore.BulkExtensions/commit/4c525151bbc24d97dfd1d532dba31a18eea067df

Ensures that only `InsertOrUpdateDelete` applies the `AlterTableColumnsToNullable` clause on the output table

Let me know if anything else should be added in here. Thanks!