### PR TITLE
Added support for HierarchyId to the master version

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -683,6 +683,94 @@ namespace EFCore.BulkExtensions.Tests
 
         }
 
+
+
+        [Fact]
+        private void HierarchyIdColumnTest()
+        {
+            ContextUtil.DbServer = DbServer.SQLServer;
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.BulkDelete(context.Categories.ToList());
+            }
+
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var nodeIdAsString = "/1/";
+                var entities = new List<Category> {
+                    new Category
+                    {
+                        Name = "Root Element",
+                        HierarchyDescription = HierarchyId.Parse(nodeIdAsString)
+                    }
+                };
+
+                context.BulkInsertOrUpdate(entities);
+            }
+        }
+
+        [Fact]
+        private void HierarchyIdIsPersistedCorrectlySimpleTest()
+        {
+            ContextUtil.DbServer = DbServer.SQLServer;
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.BulkDelete(context.Categories.ToList());
+            }
+
+            var nodeIdAsString = "/1/";
+
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var entities = new List<Category> {
+                    new Category
+                    {
+                        Name = "Root Element",
+                        HierarchyDescription = HierarchyId.Parse(nodeIdAsString)
+                    }
+            };
+                context.BulkInsertOrUpdate(entities);
+            }
+
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var category = context.Categories.Single();
+                Assert.Equal(nodeIdAsString, category.HierarchyDescription.ToString());
+            }
+
+        }
+
+        [Fact]
+        private void HierarchyIdIsPersistedCorrectlyLargerHierarchyTest()
+        {
+            ContextUtil.DbServer = DbServer.SQLServer;
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                context.BulkDelete(context.Categories.ToList());
+            }
+
+            var nodeIdAsString = "/1.1/-2/3/4/5/";
+
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var entities = new List<Category> {
+                    new Category
+                    {
+                        Name = "Deep Element",
+                        HierarchyDescription = HierarchyId.Parse(nodeIdAsString)
+                    }
+            };
+                context.BulkInsertOrUpdate(entities);
+            }
+
+            using (var context = new TestContext(ContextUtil.GetOptions()))
+            {
+                var category = context.Categories.Single();
+                Assert.Equal(nodeIdAsString, category.HierarchyDescription.ToString());
+            }
+
+        }
+
         [Fact]
         private void TablePerTypeInsertTest()
         {

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkUnderlyingTest.cs
@@ -34,6 +34,10 @@ namespace EFCore.BulkExtensions.Tests
             var connection = new SqlConnection(connectionString) as DbConnection;
             connection = new MyConnection(connection);
             builder.UseSqlServer(connection, opt => opt.UseNetTopologySuite());
+            builder.UseSqlServer(connection, conf =>
+            {
+                conf.UseHierarchyId();
+            });
             return builder.Options;
         }
 

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -32,6 +32,7 @@ namespace EFCore.BulkExtensions.Tests
         public DbSet<ChangeLog> ChangeLogs { get; set; }
         public DbSet<ItemLink> ItemLinks { get; set; }
         public DbSet<Address> Addresses { get; set; }
+        public DbSet<Category> Categories { get; set; }
 
         public DbSet<Parent> Parents { get; set; }
         public DbSet<ParentDetail> ParentDetails { get; set; }
@@ -103,6 +104,7 @@ namespace EFCore.BulkExtensions.Tests
                 modelBuilder.Entity<UdttIntInt>(entity => { entity.HasNoKey(); });
 
                 modelBuilder.Entity<Address>().Property(p => p.LocationGeometry).HasColumnType("geometry");
+                modelBuilder.Entity<Category>().Property(p => p.HierarchyDescription).HasColumnType("hierarchyid");
 
                 modelBuilder.Entity<Division>().Property(p => p.Id).HasDefaultValueSql("NEWSEQUENTIALID()");
                 modelBuilder.Entity<Department>().Property(p => p.Id).HasDefaultValueSql("NEWSEQUENTIALID()");
@@ -112,6 +114,7 @@ namespace EFCore.BulkExtensions.Tests
             {
                 modelBuilder.Entity<Address>().Ignore(p => p.LocationGeography);
                 modelBuilder.Entity<Address>().Ignore(p => p.LocationGeometry);
+                modelBuilder.Entity<Category>().Ignore(p => p.HierarchyDescription);
             }
 
             if (Database.IsSqlite())
@@ -179,6 +182,10 @@ namespace EFCore.BulkExtensions.Tests
 
                 //optionsBuilder.UseSqlServer(connectionString); // Can NOT Test with UseInMemoryDb (Exception: Relational-specific methods can only be used when the context is using a relational)
                 optionsBuilder.UseSqlServer(connectionString, opt => opt.UseNetTopologySuite()); // NetTopologySuite for Geometry / Geometry types
+                optionsBuilder.UseSqlServer(connectionString, conf =>
+                {
+                    conf.UseHierarchyId();
+                });
             }
             else if (dbServerType == DbServer.SQLite)
             {
@@ -317,6 +324,13 @@ namespace EFCore.BulkExtensions.Tests
 
         public Geometry LocationGeography { get; set; }
         public Geometry LocationGeometry { get; set; }
+    }
+
+    public class Category
+    {
+        public int CategoryId { get; set; }
+        public string Name { get; set; }
+        public HierarchyId HierarchyDescription { get; set; }
     }
 
     public class Teacher : Person

--- a/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
+++ b/EFCore.BulkExtensions/EFCore.BulkExtensions.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.0" />


### PR DESCRIPTION
I added the changes I did for the EF Core 3.1 version to the master

Using EntityFrameworkCore.SqlServer.HierarchyId Version=3.0.0