### PR TITLE
expose GetDataTable to public

### DIFF
--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -412,7 +412,7 @@ namespace EFCore.BulkExtensions.SQLAdapters.SQLServer
         /// <param name="sqlBulkCopy"></param>
         /// <param name="tableInfo"></param>
         /// <returns></returns>
-        internal static DataTable GetDataTable<T>(DbContext context, Type type, IList<T> entities, SqlBulkCopy sqlBulkCopy, TableInfo tableInfo)
+        public static DataTable GetDataTable<T>(DbContext context, Type type, IList<T> entities, SqlBulkCopy sqlBulkCopy, TableInfo tableInfo)
         {
             DataTable dataTable = InnerGetDataTable(context, ref type, entities, tableInfo);
 


### PR DESCRIPTION
expose GetDataTable to public
needed because implement costume logic based on it