### PR TITLE
Global cache for FastProperty instances.

### DIFF
--- a/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
@@ -88,14 +88,14 @@ internal static class DbContextBulkTransactionSaveChanges
                         {
                             if (property.PropertyInfo != null) // skip Shadow Property
                             {
-                                entityPropertyDict.Add(property.Name, new FastProperty(property.PropertyInfo));
+                                entityPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property.PropertyInfo));
                             }
                         }
                         foreach (var navigationPropertyInfo in navigationPropertiesInfo)
                         {
                             if (navigationPropertyInfo != null)
                             {
-                                entityPropertyDict.Add(navigationPropertyInfo.Name, new FastProperty(navigationPropertyInfo));
+                                entityPropertyDict.Add(navigationPropertyInfo.Name, FastProperty.GetOrCreate(navigationPropertyInfo));
                             }
                         }
                         fastPropertyDicts.Add(entityType.Name, entityPropertyDict);

--- a/EFCore.BulkExtensions/FastProperty.cs
+++ b/EFCore.BulkExtensions/FastProperty.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -9,6 +11,20 @@ namespace EFCore.BulkExtensions;
 /// </summary>
 public class FastProperty
 {
+    private static readonly ConcurrentDictionary<PropertyInfo, FastProperty> FastPropertyCache = new();
+    
+    /// <summary>
+    /// Get or create a <see cref="FastProperty"/> instance for getting/setting the given property.
+    /// </summary>
+    /// <param name="property">The property to obtain a <see cref="FastProperty"/> instance for.</param>
+    /// <returns>
+    /// A new or already existing and cached <see cref="FastProperty"/> instance.
+    /// </returns>
+    public static FastProperty GetOrCreate(PropertyInfo property)
+    {
+        return FastPropertyCache.GetOrAdd(property, p => new FastProperty(p));
+    }
+    
     private Func<object, object>? _getDelegate;
     private Action<object, object>? _setDelegate;
 
@@ -16,7 +32,7 @@ public class FastProperty
     /// Constructor for FastPropery
     /// </summary>
     /// <param name="property"></param>
-    public FastProperty(PropertyInfo property)
+    private FastProperty(PropertyInfo property)
     {
         Property = property;
         InitializeGet();

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -381,7 +381,7 @@ public class TableInfo
         {
             if (property.PropertyInfo != null) // skip Shadow Property
             {
-                FastPropertyDict.Add(property.Name, new FastProperty(property.PropertyInfo));
+                FastPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property.PropertyInfo));
             }
 
             var converter = property.GetTypeMapping().Converter;
@@ -483,7 +483,7 @@ public class TableInfo
             {
                 if (navigation.PropertyInfo is not null)
                 {
-                    FastPropertyDict.Add(navigation.Name, new FastProperty(navigation.PropertyInfo));
+                    FastPropertyDict.Add(navigation.Name, FastProperty.GetOrCreate(navigation.PropertyInfo));
                 }
             }
 
@@ -492,7 +492,7 @@ public class TableInfo
                 foreach (var navigationProperty in ownedTypes)
                 {
                     var property = navigationProperty.PropertyInfo;
-                    FastPropertyDict.Add(property!.Name, new FastProperty(property));
+                    FastPropertyDict.Add(property!.Name, FastProperty.GetOrCreate(property));
 
                     // If the OwnedType is mapped to the separate table, don't try merge it into its owner
                     if (OwnedTypeUtil.IsOwnedInSameTableAsOwner(navigationProperty) == false)
@@ -516,7 +516,7 @@ public class TableInfo
                             var ownedEntityPropertyFullName = property.Name + "_" + ownedEntityProperty.Name;
                             if (!FastPropertyDict.ContainsKey(ownedEntityPropertyFullName) && ownedEntityProperty.PropertyInfo is not null)
                             {
-                                FastPropertyDict.Add(ownedEntityPropertyFullName, new FastProperty(ownedEntityProperty.PropertyInfo));
+                                FastPropertyDict.Add(ownedEntityPropertyFullName, FastProperty.GetOrCreate(ownedEntityProperty.PropertyInfo));
                             }
                         }
 


### PR DESCRIPTION
This PR addresses some basics of #833 by caching `FastProperty` instances globally in a `ConcurrentDictionary`. 

I did not invest any efforts yet to allow pre-compilation of certain operations to also reduce the creation of other objects like the `TableInfo`