### PR TITLE
Fix PropertiesToExcludeOnUpdate column selection issue with postgres.

### DIFF
--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
@@ -89,7 +89,7 @@ public static class SqlQueryBuilderPostgreSql
             var updateByColumns = SqlQueryBuilder.GetCommaSeparatedColumns(tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList()).Replace("[", @"""").Replace("]", @"""");
 
             var columnsListEquals = GetColumnList(tableInfo, OperationType.Insert);
-            var columnsToUpdate = columnsListEquals.Where(c => tableInfo.PropertyColumnNamesUpdateDict.ContainsKey(c)).ToList();
+            var columnsToUpdate = columnsListEquals.Where(c => tableInfo.PropertyColumnNamesUpdateDict.ContainsValue(c)).ToList();
             var equalsColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsToUpdate, equalsTable: "EXCLUDED").Replace("[", @"""").Replace("]", @"""");
 
             q = $"INSERT INTO {tableInfo.FullTableName} ({commaSeparatedColumns}) " +


### PR DESCRIPTION
`tableInfo.PropertyColumnNamesUpdateDict` maps model/POCO property names (key) to database column names (value), and `GetColumnList()` returns database column names, thus we need to match the dictionary entries by value and not key, when selecting which columns should have their values updated.