### PR TITLE
Add support for custom type identity properties (using converters)

### DIFF
--- a/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLServer/SqlServerAdapter.cs
@@ -524,7 +524,10 @@ public class SqlOperationsServerAdapter: ISqlOperationsAdapter
                     continue;
 
                 var columnName = entityProperty.GetColumnName(objectIdentifier);
-                var propertyType = entityProperty.ClrType;
+
+                var isConvertible = tableInfo.ConvertibleColumnConverterDict.ContainsKey(columnName ?? string.Empty);
+                var propertyType = isConvertible ? tableInfo.ConvertibleColumnConverterDict[columnName ?? string.Empty].ProviderClrType : entityProperty.ClrType;
+
                 var underlyingType = Nullable.GetUnderlyingType(propertyType);
                 if (underlyingType != null)
                 {


### PR DESCRIPTION
When using custom types as identity values (for example struct wrapping an integer value), bulk operations fail because extension is trying to cast custom type to the `long` type instead. Since ValueConverters are available and used for regular properties, added some code to use them when dealing with identity values aswell.

Same issue and fix with shadow foreign key properties in sql server adapter.