### PR TITLE
Add On Conflict Update Where SQL to BulkConfig

### DIFF
--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EFCore.BulkExtensions.SQLAdapters.PostgreSql;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests;
+
+public class SqlQueryBuilderPostgreSqlTests
+{
+    [Fact]
+    public void MergeTableInsertOrUpdateWithoutOnConflictUpdateWhereSqlTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo();
+        tableInfo.IdentityColumnName = "ItemId";
+        string actual = SqlQueryBuilderPostgreSql.MergeTable<Item>(tableInfo, OperationType.InsertOrUpdate);
+
+        string expected = @"INSERT INTO ""dbo"".""Item"" (""ItemId"", ""Name"") "
+                          + @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") "
+                          + @"ON CONFLICT (""ItemId"") DO UPDATE SET ""Name"" = EXCLUDED.""Name"";";
+
+        Assert.Equal(expected, actual);
+    }
+    
+    [Fact]
+    public void MergeTableInsertOrUpdateWithOnConflictUpdateWhereSqlTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo((existing, inserted) => $"{inserted}.ItemTimestamp > {existing}.ItemTimestamp");
+        tableInfo.IdentityColumnName = "ItemId";
+        string actual = SqlQueryBuilderPostgreSql.MergeTable<Item>(tableInfo, OperationType.InsertOrUpdate);
+
+        string expected = @"INSERT INTO ""dbo"".""Item"" (""ItemId"", ""Name"") " +
+                          @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") " +
+                          @"ON CONFLICT (""ItemId"") DO UPDATE SET ""Name"" = EXCLUDED.""Name"" " +
+                          @"WHERE EXCLUDED.ItemTimestamp > ""dbo"".""Item"".ItemTimestamp;";
+
+        Assert.Equal(expected, actual);
+    }
+    
+    private TableInfo GetTestTableInfo(Func<string, string, string>? onConflictUpdateWhereSql = null)
+    {
+        var tableInfo = new TableInfo()
+        {
+            Schema = "dbo",
+            TempSchema = "dbo",
+            TableName = nameof(Item),
+            TempTableName = nameof(Item) + "Temp1234",
+            TempTableSufix = "Temp1234",
+            PrimaryKeysPropertyColumnNameDict = new Dictionary<string, string> { { nameof(Item.ItemId), nameof(Item.ItemId) } },
+            BulkConfig = new BulkConfig()
+            {
+                OnConflictUpdateWhereSql = onConflictUpdateWhereSql
+            }
+        };
+        const string nameText = nameof(Item.Name);
+
+        tableInfo.PropertyColumnNamesDict.Add(tableInfo.PrimaryKeysPropertyColumnNameDict.Keys.First(), tableInfo.PrimaryKeysPropertyColumnNameDict.Values.First());
+        tableInfo.PropertyColumnNamesDict.Add(nameText, nameText);
+        //compare on all columns (default)
+        tableInfo.PropertyColumnNamesCompareDict = tableInfo.PropertyColumnNamesDict;
+        //update all columns (default)
+        tableInfo.PropertyColumnNamesUpdateDict = tableInfo.PropertyColumnNamesDict;
+        return tableInfo;
+    }
+}

--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderSqliteTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderSqliteTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EFCore.BulkExtensions.SQLAdapters.SQLite;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests;
+
+public class SqlQueryBuilderSqliteTests
+{
+    [Fact]
+    public void MergeTableInsertOrUpdateWithoutOnConflictUpdateWhereSqlTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo();
+        tableInfo.IdentityColumnName = "ItemId";
+        string actual = SqlQueryBuilderSqlite.InsertIntoTable(tableInfo, OperationType.InsertOrUpdate);
+
+        string expected = @"INSERT INTO [Item] ([ItemId], [Name]) " +
+                          @"VALUES (@ItemId, @Name) " +
+                          @"ON CONFLICT([ItemId]) DO UPDATE SET [ItemId] = @ItemId, [Name] = @Name " +
+                          @"WHERE [ItemId] = @ItemId;";
+
+        Assert.Equal(expected, actual);
+    }
+    
+    [Fact]
+    public void MergeTableInsertOrUpdateWithOnConflictUpdateWhereSqlTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo((existing, inserted) => $"{inserted}.ItemTimestamp > {existing}.ItemTimestamp");
+        tableInfo.IdentityColumnName = "ItemId";
+        string actual = SqlQueryBuilderSqlite.InsertIntoTable(tableInfo, OperationType.InsertOrUpdate);
+
+        string expected = @"INSERT INTO [Item] ([ItemId], [Name]) " +
+                          @"VALUES (@ItemId, @Name) " +
+                          @"ON CONFLICT([ItemId]) DO UPDATE SET [ItemId] = @ItemId, [Name] = @Name " +
+                          @"WHERE [ItemId] = @ItemId AND excluded.ItemTimestamp > [Item].ItemTimestamp;";
+
+        Assert.Equal(expected, actual);
+    }
+    
+    private TableInfo GetTestTableInfo(Func<string, string, string>? onConflictUpdateWhereSql = null)
+    {
+        var tableInfo = new TableInfo()
+        {
+            Schema = "dbo",
+            TempSchema = "dbo",
+            TableName = nameof(Item),
+            TempTableName = nameof(Item) + "Temp1234",
+            TempTableSufix = "Temp1234",
+            PrimaryKeysPropertyColumnNameDict = new Dictionary<string, string> { { nameof(Item.ItemId), nameof(Item.ItemId) } },
+            BulkConfig = new BulkConfig()
+            {
+                OnConflictUpdateWhereSql = onConflictUpdateWhereSql
+            }
+        };
+        const string nameText = nameof(Item.Name);
+
+        tableInfo.PropertyColumnNamesDict.Add(tableInfo.PrimaryKeysPropertyColumnNameDict.Keys.First(), tableInfo.PrimaryKeysPropertyColumnNameDict.Values.First());
+        tableInfo.PropertyColumnNamesDict.Add(nameText, nameText);
+        //compare on all columns (default)
+        tableInfo.PropertyColumnNamesCompareDict = tableInfo.PropertyColumnNamesDict;
+        //update all columns (default)
+        tableInfo.PropertyColumnNamesUpdateDict = tableInfo.PropertyColumnNamesDict;
+        return tableInfo;
+    }
+}

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -178,9 +178,18 @@ public class BulkConfig
     ///     Used for specifying custom properties, by which we want update to be done.
     /// </summary>
     /// <remarks>
-    ///     If Identity column exisit and is not added in UpdateByProp it will be excluded automatically
+    ///     If Identity column exists and is not added in UpdateByProp it will be excluded automatically
     /// </remarks>
     public List<string>? UpdateByProperties { get; set; }
+    
+    /// <summary>
+    ///     Used for specifying a function that returns custom SQL to use for conditional updates on merges.
+    /// </summary>
+    /// <remarks>
+    ///     Function receives (existingTablePrefix, insertedTablePrefix) and should return the SQL of the WHERE clause.
+    ///     The SQLite implementation uses UPSERT functionality added in SQLite 3.24.0 (https://www.sqlite.org/lang_UPSERT.html).
+    /// </remarks>
+    public Func<string, string, string>? OnConflictUpdateWhereSql { get; set; }
 
     /// <summary>
     ///     When set to <c>true</c> it will adding (normal) Shadow Property and persist value. It Disables automatic discrimator, so it shoud be set manually.

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace EFCore.BulkExtensions.SQLAdapters.PostgreSql;
 
@@ -98,6 +99,11 @@ public static class SqlQueryBuilderPostgreSql
                 $"(SELECT {commaSeparatedColumns} FROM {tableInfo.FullTempTableName}) " +
                 $"ON CONFLICT ({updateByColumns}) " +
                 $"DO UPDATE SET {equalsColumns}";
+
+            if (tableInfo.BulkConfig.OnConflictUpdateWhereSql != null)
+            {
+                q += $" WHERE {tableInfo.BulkConfig.OnConflictUpdateWhereSql(tableInfo.FullTableName.Replace("[", @"""").Replace("]", @""""), "EXCLUDED")}";
+            }
 
             if (tableInfo.CreatedOutputTable)
             {

--- a/EFCore.BulkExtensions/SQLAdapters/SQLite/SqlQueryBuilderSqlite.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/SQLite/SqlQueryBuilderSqlite.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Data.SqlClient;
+﻿using System;
+using Microsoft.Data.SqlClient;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -63,6 +64,11 @@ public static class SqlQueryBuilderSqlite
             q += $" ON CONFLICT({commaSeparatedPrimaryKeys}) DO UPDATE" +
                  $" SET {commaSeparatedColumnsEquals}" +
                  $" WHERE {commaANDSeparatedPrimaryKeys}";
+            
+            if (tableInfo.BulkConfig.OnConflictUpdateWhereSql != null)
+            {
+                q += $" AND {tableInfo.BulkConfig.OnConflictUpdateWhereSql($"[{tableName}]", "excluded")}";
+            }
         }
 
         tableInfo.PropertyColumnNamesDict = tempDict;


### PR DESCRIPTION
Proposed solution for #846 

This adds a new `Func<string, string, string>?` property named `OnConflictUpdateWhereSql` to the `BulkConfig` class. The function will be passed two arguments: the name of the table of the existing data that is being updated (1) and the name of the table of the new data that is being inserted (2); it is expected that the function will return the SQL condition for when the new data should overwrite the existing data.

This is implemented in PostgreSQL and SQLite as a `WHERE` clause after `ON CONFLICT DO UPDATE`, and in SQL Server as a `WHEN MATCHED AND` clause after `MERGE`.