### PR TITLE
Make owned types (in same table) work in PostgreSQL.

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -417,6 +417,7 @@ public class EFCoreBulkTestAtypical
     [Theory]
     [InlineData(DbServer.SQLServer)]
     [InlineData(DbServer.SQLite)]
+    [InlineData(DbServer.PostgreSQL)]
     private void OwnedTypesTest(DbServer dbServer)
     {
         ContextUtil.DbServer = dbServer;
@@ -426,6 +427,10 @@ public class EFCoreBulkTestAtypical
         {
             context.Truncate<ChangeLog>();
             context.Database.ExecuteSqlRaw("TRUNCATE TABLE [" + nameof(ChangeLog) + "]");
+        }
+        else if (dbServer == DbServer.PostgreSQL)
+        {
+            context.Truncate<ChangeLog>();
         }
         else
         {
@@ -461,7 +466,7 @@ public class EFCoreBulkTestAtypical
         }
         context.BulkInsert(entities);
 
-        if (dbServer == DbServer.SQLServer)
+        if (dbServer == DbServer.SQLServer || dbServer == DbServer.PostgreSQL)
         {
             context.BulkRead(
                 entities,
@@ -477,7 +482,7 @@ public class EFCoreBulkTestAtypical
         entities[0].Description += " UPD";
         entities[0].Audit.InfoType = InfoType.InfoTypeB;
         context.BulkUpdate(entities);
-        if (dbServer == DbServer.SQLServer)
+        if (dbServer == DbServer.SQLServer || dbServer == DbServer.PostgreSQL)
         {
             context.BulkRead(entities);
         }

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -43,7 +43,8 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
 
         try
         {
-            string sqlCopy = SqlQueryBuilderPostgreSql.InsertIntoTable(tableInfo, tableInfo.InsertToTempTable ? OperationType.InsertOrUpdate : OperationType.Insert);
+            var operationType = tableInfo.InsertToTempTable ? OperationType.InsertOrUpdate : OperationType.Insert;
+            string sqlCopy = SqlQueryBuilderPostgreSql.InsertIntoTable(tableInfo, operationType);
 
             using var writer = isAsync ? await connection.BeginBinaryImportAsync(sqlCopy, cancellationToken).ConfigureAwait(false)
                                        : connection.BeginBinaryImport(sqlCopy);
@@ -70,12 +71,15 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
 
                 foreach (var propertyName in propertiesNames)
                 {
-                    if (tableInfo.DefaultValueProperties.Contains(propertyName) && !tableInfo.PrimaryKeysPropertyColumnNameDict.ContainsKey(propertyName))
+                    if (operationType == OperationType.Insert
+                        && tableInfo.DefaultValueProperties.Contains(propertyName) 
+                        && !tableInfo.PrimaryKeysPropertyColumnNameDict.ContainsKey(propertyName))
+                    {
                         continue;
+                    }
 
-                    var propertyValue = tableInfo.FastPropertyDict.ContainsKey(propertyName) && entity is not null ? tableInfo.FastPropertyDict[propertyName].Get(entity) : null;
+                    var propertyValue = GetPropertyValue(tableInfo, propertyName, entity);
                     var propertyColumnName = tableInfo.PropertyColumnNamesDict.ContainsKey(propertyName) ? tableInfo.PropertyColumnNamesDict[propertyName] : string.Empty;
-
                     var columnType = tableInfo.ColumnNamesTypesDict[propertyColumnName];
 
                     // string is 'text' which works fine
@@ -150,6 +154,37 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
                 }
             }
         }
+    }
+
+    static object? GetPropertyValue<T>(TableInfo tableInfo, string propertyName, T entity)
+    {
+        if (!tableInfo.FastPropertyDict.ContainsKey(propertyName.Replace('.', '_')) || entity is null)
+        {
+            return null;
+        }
+
+        object? propertyValue = entity;
+        string fullPropertyName = string.Empty;
+        foreach (var entry in propertyName.AsSpan().Split("."))
+        {
+            if (propertyValue == null)
+            {
+                return null;
+            }
+
+            if (fullPropertyName.Length > 0)
+            {
+                fullPropertyName += $"_{entry.Token}";
+            }
+            else
+            {
+                fullPropertyName = new string(entry.Token);
+            }
+            
+            propertyValue = tableInfo.FastPropertyDict[fullPropertyName].Get(propertyValue);
+        }
+
+        return propertyValue;
     }
 
     /// <inheritdoc/>

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
@@ -140,7 +140,7 @@ public static class SqlQueryBuilderPostgreSql
             }
         }
 
-        return q;
+        return q.TrimEnd(';');
     }
 
     /// <summary>

--- a/EFCore.BulkExtensions/SpanSplitExtensions.cs
+++ b/EFCore.BulkExtensions/SpanSplitExtensions.cs
@@ -1,0 +1,72 @@
+﻿namespace EFCore.BulkExtensions;
+
+using System;
+
+static class SpanSplitExtensions
+{
+    public static TokenSplitEnumerator<T> Split<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> delimiters)
+        where T : IEquatable<T>
+    {
+        return new TokenSplitEnumerator<T>(span, delimiters);
+    }
+
+    public ref struct TokenSplitEnumerator<T> where T : IEquatable<T>
+    {
+        readonly ReadOnlySpan<T> _delimiters;
+        ReadOnlySpan<T> _span;
+
+        public TokenSplitEntry<T> Current { get; private set; }
+
+        public TokenSplitEnumerator(ReadOnlySpan<T> span, ReadOnlySpan<T> delimiters)
+        {
+            this._span = span;
+            this._delimiters = delimiters;
+            this.Current = default;
+        }
+
+        public TokenSplitEnumerator<T> GetEnumerator() => this;
+
+        public bool MoveNext()
+        {
+            var span = this._span;
+
+            if (span.Length == 0)
+            {
+                return false;
+            }
+
+            var index = span.IndexOfAny(this._delimiters);
+            if (index == -1)
+            {
+                this._span = ReadOnlySpan<T>.Empty;
+                this.Current = new TokenSplitEntry<T>(span, ReadOnlySpan<T>.Empty);
+                return true;
+            }
+
+            this.Current = new TokenSplitEntry<T>(span[..index], span.Slice(index, 1));
+            this._span = span[(index + 1)..];
+
+            return true;
+        }
+    }
+
+    public readonly ref struct TokenSplitEntry<T>
+    {
+        public ReadOnlySpan<T> Token { get; }
+        public ReadOnlySpan<T> Delimiters { get; }
+        
+        public TokenSplitEntry(ReadOnlySpan<T> token, ReadOnlySpan<T> delimiters)
+        {
+            this.Token = token;
+            this.Delimiters = delimiters;
+        }
+
+        public void Deconstruct(out ReadOnlySpan<T> token, out ReadOnlySpan<T> delimiters)
+        {
+            token = this.Token;
+            delimiters = this.Delimiters;
+        }
+
+        public static implicit operator ReadOnlySpan<T>(TokenSplitEntry<T> entry) => entry.Token;
+    }
+}

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -18,6 +18,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MySqlConnector;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.Internal;
 
 namespace EFCore.BulkExtensions;
 
@@ -283,7 +284,9 @@ public class TableInfo
             }
             else if (isNpgsql)
             {
-                strategyName = nameof(Npgsql.EntityFrameworkCore.PostgreSQL.Metadata.NpgsqlValueGenerationStrategy);
+#pragma warning disable EF1001
+                strategyName = NpgsqlAnnotationNames.ValueGenerationStrategy;
+#pragma warning restore EF1001
             }
             else
             {
@@ -544,9 +547,10 @@ public class TableInfo
 
                     foreach (var ownedEntityProperty in ownedEntityProperties)
                     {
+                        string columnName = ownedEntityProperty.GetColumnName(ObjectIdentifier) ?? string.Empty;
+                        
                         if (!ownedEntityProperty.IsPrimaryKey())
                         {
-                            string columnName = ownedEntityProperty.GetColumnName(ObjectIdentifier) ?? string.Empty;
                             ownedEntityPropertyNameColumnNameDict.Add(ownedEntityProperty.Name, columnName);
                             var ownedEntityPropertyFullName = property.Name + "_" + ownedEntityProperty.Name;
                             if (!FastPropertyDict.ContainsKey(ownedEntityPropertyFullName) && ownedEntityProperty.PropertyInfo is not null)
@@ -560,6 +564,8 @@ public class TableInfo
                         {
                             ConvertibleColumnConverterDict.Add($"{navigationProperty.Name}_{ownedEntityProperty.Name}", converter);
                         }
+
+                        ColumnNamesTypesDict[columnName] = ownedEntityProperty.GetColumnType();
                     }
                     var ownedProperties = property.PropertyType.GetProperties();
                     foreach (var ownedProperty in ownedProperties)


### PR DESCRIPTION
Make owned types (in same table) work in PostgreSQL.
Fix identity annotation identification. Fixes #795 and #695 and #770 and #566 and regression from #772. With passing unit test.

@borisdj 