### PR TITLE
Owened types with spatial data

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -430,7 +430,6 @@ public class EFCoreBulkTestAtypical
         }
         else if (dbServer == DbServer.PostgreSQL)
         {
-            
             context.Truncate<ChangeLog>();
         }
         else

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -430,6 +430,7 @@ public class EFCoreBulkTestAtypical
         }
         else if (dbServer == DbServer.PostgreSQL)
         {
+            
             context.Truncate<ChangeLog>();
         }
         else
@@ -488,6 +489,67 @@ public class EFCoreBulkTestAtypical
         }
         Assert.Equal("Dsc 1 UPD", entities[0].Description);
         Assert.Equal(InfoType.InfoTypeB, entities[0].Audit.InfoType);
+    }
+
+    [Theory]
+    [InlineData(DbServer.SQLServer)]
+    private void OwnedTypeSpatialDataTest(DbServer dbServer)
+    {
+        ContextUtil.DbServer = dbServer;
+        using var context = new TestContext(ContextUtil.GetOptions());
+
+        if (dbServer == DbServer.SQLServer)
+        {
+            context.Truncate<Tracker>();
+            context.Database.ExecuteSqlRaw("TRUNCATE TABLE [" + nameof(Tracker) + "]");
+        }
+        else if (dbServer == DbServer.PostgreSQL)
+        {
+            context.Truncate<ChangeLog>();
+        }
+        else
+        {
+            //context.ChangeLogs.BatchDelete(); // TODO
+            context.BulkDelete(context.ChangeLogs.ToList());
+        }
+
+        var entities = new List<Tracker>();
+        for (int i = 1; i <= EntitiesNumber; i++)
+        {
+            entities.Add(new Tracker
+            {
+                Description = "Dsc " + i,
+                Location = new TrackerLocation()
+                {
+                    LocationName = "Anywhere",
+                    Location = new Point(0, 0) { SRID = 4326 }
+                }
+            });
+        }
+        context.BulkInsert(entities);
+
+        if (dbServer == DbServer.SQLServer || dbServer == DbServer.PostgreSQL)
+        {
+            context.BulkRead(
+                entities,
+                new BulkConfig
+                {
+                    UpdateByProperties = new List<string> { nameof(Item.Description) }
+                }
+            );
+            Assert.Equal(2, entities[1].TrackerId);
+        }
+
+        // TEST
+        entities[0].Description += " UPD";
+        entities[0].Location.Location = new Point(1, 1) { SRID = 4326 };
+        context.BulkUpdate(entities);
+        if (dbServer == DbServer.SQLServer || dbServer == DbServer.PostgreSQL)
+        {
+            context.BulkRead(entities);
+        }
+        Assert.Equal("Dsc 1 UPD", entities[0].Description);
+        Assert.Equal(new Point(1, 1) { SRID = 4326 }, entities[0].Location.Location);
     }
 
     [Theory]

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -38,6 +38,7 @@ public class TestContext : DbContext
     public DbSet<Modul> Moduls { get; set; } = null!;
     public DbSet<Info> Infos { get; set; } = null!;
     public DbSet<ChangeLog> ChangeLogs { get; set; } = null!;
+    public DbSet<Tracker> Trackers { get; set; } = null!;
     public DbSet<ItemLink> ItemLinks { get; set; } = null!;
     public DbSet<Address> Addresses { get; set; } = null!;
     public DbSet<Category> Categories { get; set; } = null!;
@@ -101,6 +102,8 @@ public class TestContext : DbContext
         modelBuilder.Entity<ChangeLog>().OwnsOne(a => a.Audit,
             b => b.Property(p => p.InfoType).HasConversion(new EnumToStringConverter<InfoType>()));
 
+        modelBuilder.Entity<Tracker>().OwnsOne(t => t.Location);
+        
         modelBuilder.Entity<Person>().HasIndex(a => a.Name)
             .IsUnique(); // In SQLite UpdateByColumn(nonPK) requires it has UniqueIndex
 
@@ -633,6 +636,20 @@ public class AuditExtended
 
     [NotMapped]
     public string Remark { get; set; } = null!;
+}
+public class Tracker
+{
+    public int TrackerId { get; set; }
+
+    public string Description { get; set; } = null!;
+
+    public TrackerLocation Location { get; set; } = null!;
+}
+[Owned]
+public class TrackerLocation
+{
+    public string LocationName { get; set; } = null!;
+    public Point Location { get; set; } = null!;
 }
 
 // For testing BatchUpdate expressions that use nested queries


### PR DESCRIPTION
Hi,

I found, that Owened Types that contain spatial data like

[Owned]
public class TrackerLocation
{
    public string LocationName { get; set; } = null!;
    public Point Location { get; set; } = null!;
}
are failing when used in types that are Bulk Inserted/Updated.

The problem was, that the Geometry Logic, that is used in normal Properties was not used on Properties of Owned Types.

I added that logic and created a Unit Test for it.

It is also only for SQL Server (since the Geometry Handling for normal Properties is only working in SQL Server)