### PR TITLE
fix #904 - bulk update on postgres insert only

### DIFF
--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
@@ -16,7 +16,7 @@ public class SqlQueryBuilderPostgreSqlTests
         string actual = SqlQueryBuilderPostgreSql.MergeTable<Item>(tableInfo, OperationType.InsertOrUpdate);
 
         string expected = @"INSERT INTO ""dbo"".""Item"" (""ItemId"", ""Name"") "
-                          + @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") "
+                          + @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") LIMIT 1 "
                           + @"ON CONFLICT (""ItemId"") DO UPDATE SET ""Name"" = EXCLUDED.""Name"";";
 
         Assert.Equal(expected, actual);
@@ -30,9 +30,24 @@ public class SqlQueryBuilderPostgreSqlTests
         string actual = SqlQueryBuilderPostgreSql.MergeTable<Item>(tableInfo, OperationType.InsertOrUpdate);
 
         string expected = @"INSERT INTO ""dbo"".""Item"" (""ItemId"", ""Name"") " +
-                          @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") " +
+                          @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") LIMIT 1 " +
                           @"ON CONFLICT (""ItemId"") DO UPDATE SET ""Name"" = EXCLUDED.""Name"" " +
                           @"WHERE EXCLUDED.ItemTimestamp > ""dbo"".""Item"".ItemTimestamp;";
+
+        Assert.Equal(expected, actual);
+    }
+    
+    [Fact]
+    public void MergeTableInsertOrUpdateWithInsertOnlyTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo();
+        tableInfo.IdentityColumnName = "ItemId";
+        tableInfo.PropertyColumnNamesUpdateDict = new();
+        string actual = SqlQueryBuilderPostgreSql.MergeTable<Item>(tableInfo, OperationType.InsertOrUpdate);
+
+        string expected = @"INSERT INTO ""dbo"".""Item"" (""ItemId"", ""Name"") "
+                          + @"(SELECT ""ItemId"", ""Name"" FROM ""dbo"".""ItemTemp1234"") LIMIT 1 "
+                          + @"ON CONFLICT (""ItemId"") DO NOTHING;";
 
         Assert.Equal(expected, actual);
     }


### PR DESCRIPTION
Fix for issue 904 (PostgreSql):

Problems
- `BulkInsertOrUpdate` fails when `PropertiesToIncludeOnUpdate` contains empty list
- `BulkInsertOrUpdate` fails when `PropertiesToIncludeOnUpdate` contains same as `UpdateByProperties`

Fix:
- Replace `DO UPDATE SET <empty>` with `DO NOTHING` to provide valid sql
- Add `LIMIT 1` before `ON CONFLICT` to prevent `ON CONFLICT DO UPDATE command cannot affect row a second time`
- Add a unit test case to ensure, the handling is correct

Concerns with this PR:
- Please double re-check, that `LIMIT 1` does not have unwanted side effects in other cases

Thank you.
