### PR TITLE
Add missing .ConfigureAwait(false) everywhere

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ end_of_line = lf
 trim_trailing_whitespace = false
 insert_final_newline = true
 csharp_style_namespace_declarations = file_scoped:warning
+dotnet_diagnostic.CA2007.severity = warning

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EFCore.BulkExtensions/DbContextBulkTransaction.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransaction.cs
@@ -74,11 +74,11 @@ internal static class DbContextBulkTransaction
 
             if (operationType == OperationType.SaveChanges)
             {
-                await DbContextBulkTransactionSaveChanges.SaveChangesAsync(context, bulkConfig, progress, cancellationToken);
+                await DbContextBulkTransactionSaveChanges.SaveChangesAsync(context, bulkConfig, progress, cancellationToken).ConfigureAwait(false);
             }
             else if(bulkConfig?.IncludeGraph == true)
             {
-                await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken);
+                await DbContextBulkTransactionGraphUtil.ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -86,19 +86,19 @@ internal static class DbContextBulkTransaction
 
                 if (operationType == OperationType.Insert && !tableInfo.BulkConfig.SetOutputIdentity)
                 {
-                    await SqlBulkOperation.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken);
+                    await SqlBulkOperation.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
                 }
                 else if (operationType == OperationType.Read)
                 {
-                    await SqlBulkOperation.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken);
+                    await SqlBulkOperation.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
                 }
                 else if (operationType == OperationType.Truncate)
                 {
-                    await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken);
+                    await SqlBulkOperation.TruncateAsync(context, tableInfo, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await SqlBulkOperation.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken);
+                    await SqlBulkOperation.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionGraphUtil.cs
@@ -19,7 +19,7 @@ internal static class DbContextBulkTransactionGraphUtil
 
     public static async Task ExecuteWithGraphAsync(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal>? progress, CancellationToken cancellationToken)
     {
-        await ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, isAsync: true, cancellationToken);
+        await ExecuteWithGraphAsync(context, entities, operationType, bulkConfig, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task ExecuteWithGraphAsync(DbContext context, IEnumerable<object> entities, OperationType operationType, BulkConfig bulkConfig, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
@@ -47,7 +47,7 @@ internal static class DbContextBulkTransactionGraphUtil
 
         // Inserting an entity graph must be done within a transaction otherwise the database could end up in a bad state
         var hasExistingTransaction = context.Database.CurrentTransaction != null;
-        var transaction = context.Database.CurrentTransaction ?? (isAsync ? await context.Database.BeginTransactionAsync(cancellationToken) : context.Database.BeginTransaction());
+        var transaction = context.Database.CurrentTransaction ?? (isAsync ? await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false) : context.Database.BeginTransaction());
 
         try
         {
@@ -71,7 +71,7 @@ internal static class DbContextBulkTransactionGraphUtil
 
                 if (isAsync)
                 {
-                    await SqlBulkOperation.MergeAsync(context, entityClrType, entitiesToAction, tableInfo, operationType, progress, cancellationToken);
+                    await SqlBulkOperation.MergeAsync(context, entityClrType, entitiesToAction, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -88,7 +88,7 @@ internal static class DbContextBulkTransactionGraphUtil
 
                     if (isAsync)
                     {
-                        await SqlBulkOperation.MergeAsync(context, entityClrType, dependentsOfSameType, dependentTableInfo, operationType, progress, cancellationToken);
+                        await SqlBulkOperation.MergeAsync(context, entityClrType, dependentsOfSameType, dependentTableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -101,7 +101,7 @@ internal static class DbContextBulkTransactionGraphUtil
             {
                 if (isAsync)
                 {
-                    await transaction.CommitAsync(cancellationToken);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -115,7 +115,7 @@ internal static class DbContextBulkTransactionGraphUtil
             {
                 if (isAsync)
                 {
-                    await transaction.DisposeAsync();
+                    await transaction.DisposeAsync().ConfigureAwait(false);
                 }
                 else
                 {

--- a/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
@@ -214,7 +214,7 @@ internal static class DbContextBulkTransactionSaveChanges
                 var task = (Task?)bulkMethod.Invoke(null, methodArguments);
                 if (task != null)
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
             }
 

--- a/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
@@ -100,7 +100,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
     {
         //Because of using temp table in case of update, we need to access created temp table in Insert method.
         var hasExistingTransaction = context.Database.CurrentTransaction != null;
-        var transaction = context.Database.CurrentTransaction ?? (isAsync ? await context.Database.BeginTransactionAsync(cancellationToken) : context.Database.BeginTransaction());
+        var transaction = context.Database.CurrentTransaction ?? (isAsync ? await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false) : context.Database.BeginTransaction());
         
         if (tableInfo.BulkConfig.CustomSourceTableName == null)
         {
@@ -198,7 +198,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
             {
                 if (isAsync)
                 {
-                    await transaction.CommitAsync(cancellationToken);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -253,7 +253,7 @@ public class MySqlAdapter : ISqlOperationsAdapter
                 {
                     if (isAsync)
                     {
-                        await transaction.DisposeAsync();
+                        await transaction.DisposeAsync().ConfigureAwait(false);
                     }
                     else
                     {

--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -145,7 +145,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
             {
                 if (isAsync)
                 {
-                    await connection.CloseAsync();
+                    await connection.CloseAsync().ConfigureAwait(false);
                 }
                 else
                 {
@@ -218,7 +218,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
             }
         }
 
-        bool hasUniqueConstrain = await CheckHasExplicitUniqueConstrainAsync(context, tableInfo, isAsync,  cancellationToken);
+        bool hasUniqueConstrain = await CheckHasExplicitUniqueConstrainAsync(context, tableInfo, isAsync,  cancellationToken).ConfigureAwait(false);
         if (hasUniqueConstrain == false)
         {
             if (tableInfo.EntityPKPropertyColumnNameDict == tableInfo.PrimaryKeysPropertyColumnNameDict)
@@ -330,7 +330,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
 
     /// <inheritdoc/>
     protected async Task ReadAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken) where T : class
-        =>  await MergeAsync(context, type, entities, tableInfo, OperationType.Read, progress, isAsync, cancellationToken);
+        =>  await MergeAsync(context, type, entities, tableInfo, OperationType.Read, progress, isAsync, cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc/>
     public void Truncate(DbContext context, TableInfo tableInfo)

--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
@@ -109,7 +109,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
     /// <inheritdoc/>
     public async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken) where T : class
     {
-        await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, cancellationToken);
+        await MergeAsync(context, type, entities, tableInfo, operationType, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
     
     /// <inheritdoc/>
@@ -270,7 +270,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
                 {
                     if (transaction is not null)
                     {
-                        await transaction.DisposeAsync();
+                        await transaction.DisposeAsync().ConfigureAwait(false);
                     }
 
                     await context.Database.CloseConnectionAsync().ConfigureAwait(false);

--- a/EFCore.BulkExtensions/SqlBulkOperation.cs
+++ b/EFCore.BulkExtensions/SqlBulkOperation.cs
@@ -59,7 +59,7 @@ internal static class SqlBulkOperation
     public static async Task InsertAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress, CancellationToken cancellationToken)
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter();
-        await adapter.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken);
+        await adapter.InsertAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
     }
 
     public static void Merge<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress) where T : class
@@ -71,7 +71,7 @@ internal static class SqlBulkOperation
     public static async Task MergeAsync<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress, CancellationToken cancellationToken = default) where T : class
     {
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter();
-        await adapter.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken);
+        await adapter.MergeAsync(context, type, entities, tableInfo, operationType, progress, cancellationToken).ConfigureAwait(false);
     }
 
     public static void Read<T>(DbContext context, Type type, IList<T> entities, TableInfo tableInfo, Action<decimal>? progress) where T : class
@@ -91,7 +91,7 @@ internal static class SqlBulkOperation
             await context.Database.ExecuteSqlRawAsync(SqlQueryBuilder.DropTable(tableInfo.FullTempTableName, tableInfo.BulkConfig.UseTempDB), cancellationToken).ConfigureAwait(false);
         }
         var adapter = SqlAdaptersMapping.CreateBulkOperationsAdapter();
-        await adapter.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken);
+        await adapter.ReadAsync(context, type, entities, tableInfo, progress, cancellationToken).ConfigureAwait(false);
     }
 
     public static void Truncate(DbContext context, TableInfo tableInfo)


### PR DESCRIPTION
Also set the CA2007 severity as warning which will end up as an error since `TreatWarningsAsErrors` is enabled. (But disable them in the test project where they are not required.)

See also [Overview of .NET source code analysis][1] for more information about the .NET analyzers and how to configure them.

[1]: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview