### PR TITLE
[Postgresql] Remove FROM in batch update if no JOINs to other tables 

### DIFF
--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
@@ -9,6 +9,34 @@ namespace EFCore.BulkExtensions.Tests;
 public class SqlQueryBuilderPostgreSqlTests
 {
     [Fact]
+    public void RestructureForBatchWithoutJoinToOtherTablesTest()
+    {
+        string sql =
+            @"UPDATE i SET ""Description"" = @Description, ""Price"" = @Price FROM ""Item"" AS i WHERE i.""ItemId"" <= 1";
+        
+        string expected =
+            @"UPDATE ""Item"" AS i SET ""Description"" = @Description, ""Price"" = @Price WHERE i.""ItemId"" <= 1";
+        
+        var batchUpdate = SqlQueryBuilderPostgreSql.RestructureForBatch(sql);
+        
+        Assert.Equal(expected, batchUpdate);
+    }
+    
+    [Fact]
+    public void RestructureForBatchWithJoinToOtherTablesTest()
+    {
+        string sql =
+            @"UPDATE i SET ""Description"" = @Description, ""Price"" = @Price FROM ""Item"" AS i INNER JOIN ""User"" AS u ON i.""UserId"" = u.""Id"" WHERE i.""ItemId"" <= 1";
+        
+        string expected =
+            @"UPDATE ""Item"" AS i SET ""Description"" = @Description, ""Price"" = @Price FROM ""User"" AS u WHERE i.""ItemId"" <= 1 AND i.""UserId"" = u.""Id"" ";
+        
+        var batchUpdate = SqlQueryBuilderPostgreSql.RestructureForBatch(sql);
+        
+        Assert.Equal(expected, batchUpdate);
+    }
+    
+    [Fact]
     public void MergeTableInsertOrUpdateWithoutOnConflictUpdateWhereSqlTest()
     {
         TableInfo tableInfo = GetTestTableInfo();

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
@@ -310,7 +310,7 @@ public static class SqlQueryBuilderPostgreSql
             //TO
             // UPDATE "Item" AS i SET "Description" = 'Update N', "Price" = 1.5 WHERE i."ItemId" <= 1
             //WOULD ALSO WORK
-            // UPDATE "Item" SET "Description" = 'Update N', "Price" = 1.5 FROM "Item" WHERE "ItemId" <= 1
+            // UPDATE "Item" SET "Description" = 'Update N', "Price" = 1.5 WHERE "ItemId" <= 1
             
             // if JOIN exists:
             //FROM

--- a/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
+++ b/EFCore.BulkExtensions/SQLAdapters/PostgreSql/SqlQueryBuilderPostgreSql.cs
@@ -308,15 +308,24 @@ public static class SqlQueryBuilderPostgreSql
             //FROM
             // UPDATE i SET "Description" = @Description, "Price\" = @Price FROM "Item" AS i WHERE i."ItemId" <= 1
             //TO
-            // UPDATE "Item" AS i SET "Description" = 'Update N', "Price" = 1.5 FROM "Item" WHERE i."ItemId" <= 1
+            // UPDATE "Item" AS i SET "Description" = 'Update N', "Price" = 1.5 WHERE i."ItemId" <= 1
             //WOULD ALSO WORK
             // UPDATE "Item" SET "Description" = 'Update N', "Price" = 1.5 FROM "Item" WHERE "ItemId" <= 1
-
+            
+            // if JOIN exists:
+            //FROM
+            // UPDATE i SET "Description" = @Description, "Price\" = @Price FROM "Item" AS i INNER JOIN "User" AS u ON i."UserId" = u."Id" WHERE i."ItemId" <= 1
+            //TO
+            // UPDATE "Item" AS i SET "Description" = 'Update N', "Price" = 1.5 FROM "User" AS u WHERE i."ItemId" <= 1 AND i."UserId" = u."Id"
+            
+            
             string tableAS = sql.Substring(sql.IndexOf("FROM") + 4, sql.IndexOf($"AS {firstLetterOfTable}") - sql.IndexOf("FROM"));
             
             if (!sql.Contains("JOIN"))
             {
                 sql = sql.Replace($"AS {firstLetterOfTable}", "");
+                string fromClause = sql.Substring(sql.IndexOf("FROM"), sql.IndexOf("WHERE") - sql.IndexOf("FROM"));
+                sql = sql.Replace(fromClause, "");
             }
             else
             {


### PR DESCRIPTION
In postgresql, if batch update has no joins to other table, 'target table' should not be repeated.

According to postgresql documentation:
 "Do not repeat the target table as a from_item unless you intend a self-join"

 https://www.postgresql.org/docs/current/sql-update.html