### PR TITLE
Gracefully Handle a wrapped QueryProvider (Delegate Decompiler support during Batch operations)

### DIFF
--- a/EFCore.BulkExtensions.Tests/DelegateDecompilerTests.cs
+++ b/EFCore.BulkExtensions.Tests/DelegateDecompilerTests.cs
@@ -1,0 +1,20 @@
+﻿using DelegateDecompiler.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests;
+public class DelegateDecompilerTests
+{
+    [Fact]
+    public async Task DelegateDecompiler_DecompileAsync_WorksAsync()
+    {
+        using var context = new TestContext(ContextUtil.GetOptions());
+
+        await context.Items
+            .Where(x => x.ItemId < 0)
+            .DecompileAsync()
+            .BatchDeleteAsync()
+        ;
+    }
+}

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DelegateDecompiler.EntityFrameworkCore5" Version="0.32.0" />
     <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.8" />

--- a/EFCore.BulkExtensions/BatchUtil.cs
+++ b/EFCore.BulkExtensions/BatchUtil.cs
@@ -533,7 +533,17 @@ public static class BatchUtil
     {
 #pragma warning disable EF1001 // Internal EF Core API usage.
         const BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
-        var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags)?.GetValue(query.Provider);
+
+        var provider = query.Provider;
+
+        if (provider is not EntityQueryProvider) // handling wrapped instances for cases like the DelegateDecompiler
+        {
+            var providerProp = query.Provider.GetType().GetProperties(bindingFlags).FirstOrDefault(x => x.PropertyType == typeof(IQueryProvider));
+
+            provider = providerProp?.GetValue(query.Provider) as IQueryProvider ?? throw new NotSupportedException($"Could not an EntityQueryProvider either directly or from a wrapped instance");
+        }
+
+        var queryCompiler = typeof(EntityQueryProvider).GetField("_queryCompiler", bindingFlags)?.GetValue(provider);
         var queryContextFactory = queryCompiler?.GetType().GetField("_queryContextFactory", bindingFlags)?.GetValue(queryCompiler);
 
         var dependencies = typeof(RelationalQueryContextFactory).GetProperty("Dependencies", bindingFlags)?.GetValue(queryContextFactory);


### PR DESCRIPTION
The [DelegateDecompiler](https://github.com/hazzik/DelegateDecompiler) library ends up wrapping the EntityQueryProvider in its own instance.  

The reflection behavior of looking up the private `_queryCompiler` field fails in this case. 

This PR aims to add graceful handling of a wrapped EntityQueryProvider instance for this use case.

DelegateDecompiler does the same pattern for all of its flavors of EF (EF6, EFCore, EFCore5+) so testing against DelegateDecompiler.EFCore5 is probably sufficient in this scenario.