### PR TITLE
TimeStamp on tables without indentity #1004

### DIFF
--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -1134,7 +1134,7 @@ public class TableInfo
         bool hasIdentity = OutputPropertyColumnNamesDict.Any(a => a.Value == IdentityColumnName) ||
                            (tableInfo.HasSinglePrimaryKey && tableInfo.DefaultValueProperties.Contains(tableInfo.PrimaryKeysPropertyColumnNameDict.FirstOrDefault().Key));
         int totalNumber = entities.Count;
-        if (BulkConfig.SetOutputIdentity && hasIdentity)
+        if (BulkConfig.SetOutputIdentity && (hasIdentity || BulkConfig.DoNotUpdateIfTimeStampChanged))
         {
             var databaseType = SqlAdaptersMapping.GetDatabaseType(context);
             string sqlQuery = databaseType == DbServer.SQLServer? SqlQueryBuilder.SelectFromOutputTable(this) : SqlQueryBuilderMySql.SelectFromOutputTable(this);


### PR DESCRIPTION
Expanded the condition in TableInfo to load data even when we don't have a identity column, but still want TimeStamps to be handled