### PR TITLE
Feature/net7

### DIFF
--- a/EFCore.BulkExtensions.Common/EFCore.BulkExtensions.Common.csproj
+++ b/EFCore.BulkExtensions.Common/EFCore.BulkExtensions.Common.csproj
@@ -29,13 +29,13 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-	<PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
-    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
+      <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
   </ItemGroup>
 
-    <!-- net 6.0 -->
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <!-- net 6.0 -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
@@ -44,6 +44,8 @@
 
     <!-- net 7.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="4.0.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0-alpha.1" />

--- a/EFCore.BulkExtensions.Common/EFCore.BulkExtensions.Common.csproj
+++ b/EFCore.BulkExtensions.Common/EFCore.BulkExtensions.Common.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Title>EFCore.BulkExtensions</Title>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>6.6.2</Version>
+    <Version>7.0.0-alpha.1</Version>
 	<Nullable>enable</Nullable>	  
     <Authors>borisdj</Authors>
     <Description>EntityFramework EF Core Bulk Batch Extensions for Insert Update Delete Read (CRUD) operations on SQL Server, PostgreSQL, MySQL, SQLite</Description>
@@ -31,12 +31,24 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
 	<PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
-	<PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.11" />
+    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
   </ItemGroup>
+
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.11" />
+    </ItemGroup>
+
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0-alpha.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.0" />
+    </ItemGroup>
   
   <ItemGroup>
     <None Include="..\EFCoreBulk.png">

--- a/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
+++ b/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
@@ -27,18 +27,16 @@
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
-  </ItemGroup>
-
     <!-- net 6.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
     </ItemGroup>
 
     <!-- net 7.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="4.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0-alpha.1" />
     </ItemGroup>

--- a/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
+++ b/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <Title>EFCore.BulkExtensions.MySql</Title>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <Version>6.6.2</Version>
+        <Version>7.0.0-alpha.1</Version>
         <Nullable>enable</Nullable>
         <Authors>borisdj</Authors>
         <Description>EntityFramework EF Core Bulk Batch Extensions for Insert Update Delete Read (CRUD) operations on SQL Server, PostgreSQL, MySQL, SQLite</Description>
@@ -29,11 +29,21 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
   </ItemGroup>
 
-  <ItemGroup>
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    </ItemGroup>
+
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0-alpha.1" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Include="..\EFCoreBulk.png">
           <Pack>True</Pack>
           <PackagePath></PackagePath>

--- a/EFCore.BulkExtensions.PostgreSql/EFCore.BulkExtensions.PostgreSql.csproj
+++ b/EFCore.BulkExtensions.PostgreSql/EFCore.BulkExtensions.PostgreSql.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
       <Title>EFCore.BulkExtensions.PostgreSql</Title>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <Version>6.6.2</Version>
+      <Version>7.0.0-alpha.1</Version>
       <Nullable>enable</Nullable>
       <Authors>borisdj</Authors>
       <Description>EntityFramework EF Core Bulk Batch Extensions for Insert Update Delete Read (CRUD) operations on SQL Server, PostgreSQL, MySQL, SQLite</Description>
@@ -27,11 +27,17 @@
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-  </ItemGroup>
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+    </ItemGroup>
 
-  <ItemGroup>
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Include="..\EFCoreBulk.png">
           <Pack>True</Pack>
           <PackagePath></PackagePath>

--- a/EFCore.BulkExtensions.SQLite/EFCore.BulkExtensions.SQLite.csproj
+++ b/EFCore.BulkExtensions.SQLite/EFCore.BulkExtensions.SQLite.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
       <Title>EFCore.BulkExtensions.SQLite</Title>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <Version>6.6.2</Version>
+      <Version>7.0.0-alpha.1</Version>
       <Nullable>enable</Nullable>
       <Authors>borisdj</Authors>
       <Description>EntityFramework EF Core Bulk Batch Extensions for Insert Update Delete Read (CRUD) operations on SQL Server, PostgreSQL, MySQL, SQLite</Description>
@@ -27,11 +27,17 @@
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.11" />
-  </ItemGroup>
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="6.0.11" />
+    </ItemGroup>
 
-  <ItemGroup>
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
       <None Include="..\EFCoreBulk.png">
           <Pack>True</Pack>
           <PackagePath></PackagePath>

--- a/EFCore.BulkExtensions.SqlServer/EFCore.BulkExtensions.SqlServer.csproj
+++ b/EFCore.BulkExtensions.SqlServer/EFCore.BulkExtensions.SqlServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -28,17 +28,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
       <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
   </ItemGroup>
 
     <!-- net 6.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
     </ItemGroup>
 
     <!-- net 7.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="4.0.0" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
     </ItemGroup>
 

--- a/EFCore.BulkExtensions.SqlServer/EFCore.BulkExtensions.SqlServer.csproj
+++ b/EFCore.BulkExtensions.SqlServer/EFCore.BulkExtensions.SqlServer.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Title>EFCore.BulkExtensions.SqlServer</Title>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>6.6.2</Version>
+    <Version>7.0.0-alpha.1</Version>
     <Nullable>enable</Nullable>
     <Authors>borisdj</Authors>
     <Description>EntityFramework EF Core Bulk Batch Extensions for Insert Update Delete Read (CRUD) operations on SQL Server, PostgreSQL, MySQL, SQLite</Description>
@@ -30,8 +30,17 @@
   <ItemGroup>
       <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
       <PackageReference Include="NetTopologySuite.IO.SqlServerBytes" Version="2.1.0" />
-      <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
+
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    </ItemGroup>
+
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+    </ItemGroup>
 
   <ItemGroup>
       <None Include="..\EFCoreBulk.png">

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,12 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
     <PackageReference Include="RT.Comb" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -23,6 +18,24 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.2" />
+    </ItemGroup>
+
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0-alpha.1" />
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EFCore.BulkExtensions.Common\EFCore.BulkExtensions.Common.csproj" />

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="RT.Comb" Version="3.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.3" />
@@ -21,6 +20,7 @@
 
     <!-- net 6.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="3.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="6.0.11" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
@@ -30,6 +30,7 @@
 
     <!-- net 7.0 -->
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="4.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />

--- a/EFCore.BulkExtensionsCore/BatchUtil.cs
+++ b/EFCore.BulkExtensionsCore/BatchUtil.cs
@@ -640,7 +640,7 @@ public static class BatchUtil
     public static readonly Regex TableAliasPattern = new(@"(?:FROM|JOIN)\s+(\[\S+\]) AS (\[\S+\])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
-    /// Attempt to create a DbParameter using the <see cref="Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping.CreateParameter(DbCommand, string, object, bool?)"/>
+    /// Attempt to create a DbParameter using the Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping.CreateParameter(DbCommand, string, object, bool?)
     /// call for the specified column name.
     /// </summary>
     public static DbParameter? TryCreateRelationalMappingParameter(string? columnName, string parameterName, object? value, TableInfo? tableInfo)

--- a/EFCore.BulkExtensionsCore/EFCore.BulkExtensionsCore.csproj
+++ b/EFCore.BulkExtensionsCore/EFCore.BulkExtensionsCore.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Title>EFCore.BulkExtensionsCore</Title>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>6.6.2</Version>
+    <Version>7.0.0-alpha.1</Version>
 	<Nullable>enable</Nullable>	  
     <Authors>borisdj</Authors>
     <Description>EFCore.BulkExtensions shared project with base code for all provider</Description>
@@ -23,8 +23,17 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.11" />
   </ItemGroup>
+
+    <!-- net 6.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.11" />
+    </ItemGroup>
+
+    <!-- net 7.0 -->
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+    </ItemGroup>
 
   <ItemGroup>
     <None Include="..\EFCoreBulk.png">


### PR DESCRIPTION
Should go away at solving #993 

I set the TFM to both net6 and net7 and then moved all packages so that they'd use the right nuget version.

I ran the tests for SqlServer, MySql and SQLite, these were all good except a couple failed for net7 (net6 were all green).
I skipped Postgres tests because i don't have a db for that running.

![image](https://user-images.githubusercontent.com/8641495/206739451-5f759cc2-dbe2-4b1d-8d2b-8aa6c5f3c92a.png)

I had some SQLite issues `The process cannot access the file because it is being used by another process.` - i did not look into this and skipped those tests.
These seemed to be easy to fix, like for example slightly different SQL being generated in net7:

![image](https://user-images.githubusercontent.com/8641495/206739048-e05b153a-01bf-43f8-9ed8-1abc4557b5d9.png)

I then installed this package into my own net7 project, it uses a lot of different configurations of BulkOptions and I did not see any issues.

I named this version 7.0.0-beta.1, the same name as the `Pomelo.EntityFrameworkCore.MySql` package. I'd be great if at some point we'd have atleast a beta package that supports .net7.

Feel free to do anything with this PR as you see fit.