### PR TITLE
fix: find EF7 GetCommand via reflection as workaround

### DIFF
--- a/EFCore.BulkExtensions/Helpers/QuerySqlGeneratorHelpers.cs
+++ b/EFCore.BulkExtensions/Helpers/QuerySqlGeneratorHelpers.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace EFCore.BulkExtensions.Helpers;
+
+internal static class QuerySqlGeneratorHelpers
+{
+
+    private static Func<QuerySqlGenerator, SelectExpression, IRelationalCommand>? _getCommandFunc;
+
+    public static IRelationalCommand GetCommand(QuerySqlGenerator querySqlGenerator, SelectExpression selectExpression)
+    {
+        if (_getCommandFunc == null)
+            return querySqlGenerator.GetCommand(selectExpression);
+        return _getCommandFunc(querySqlGenerator, selectExpression);
+    }
+    
+    static QuerySqlGeneratorHelpers()
+    {
+        InitGetCommand();
+    }
+
+    private static void InitGetCommand()
+    {
+        // EF6 uses GetCommand(SelectExpression)
+        // EF7 uses GetCommand(Expression)
+        // See: https://github.com/dotnet/efcore/blob/3f82c2b0af132b7019f6bd8b32c2709469b0ffae/src/EFCore.Relational/Query/QuerySqlGenerator.cs#L67
+        var methodInfo = typeof(QuerySqlGenerator)
+            .GetMethod(nameof(QuerySqlGenerator.GetCommand), new[] { typeof(Expression) });
+
+        if (methodInfo != null)
+        {
+            _getCommandFunc =
+                (Func<QuerySqlGenerator, SelectExpression, IRelationalCommand>)Delegate.CreateDelegate(
+                    typeof(Func<QuerySqlGenerator, SelectExpression, IRelationalCommand>), methodInfo);
+        }
+    }
+}

--- a/EFCore.BulkExtensions/Helpers/QuerySqlGeneratorHelpers.cs
+++ b/EFCore.BulkExtensions/Helpers/QuerySqlGeneratorHelpers.cs
@@ -8,9 +8,19 @@ namespace EFCore.BulkExtensions.Helpers;
 
 internal static class QuerySqlGeneratorHelpers
 {
-
+    /// <summary>
+    /// Cached delegate.
+    /// For more info see: https://codeblog.jonskeet.uk/2008/08/09/making-reflection-fly-and-exploring-delegates/
+    /// </summary>
     private static Func<QuerySqlGenerator, SelectExpression, IRelationalCommand>? _getCommandFunc;
 
+    /// <summary>
+    /// Retrieves a <see cref="IRelationalCommand"/> using <see cref="QuerySqlGenerator.GetCommand"/>,
+    /// But also applies a fix when used with EF7
+    /// </summary>
+    /// <param name="querySqlGenerator"></param>
+    /// <param name="selectExpression"></param>
+    /// <returns></returns>
     public static IRelationalCommand GetCommand(QuerySqlGenerator querySqlGenerator, SelectExpression selectExpression)
     {
         if (_getCommandFunc == null)
@@ -25,8 +35,8 @@ internal static class QuerySqlGeneratorHelpers
 
     private static void InitGetCommand()
     {
-        // EF6 uses GetCommand(SelectExpression)
-        // EF7 uses GetCommand(Expression)
+        // EF6 uses QuerySqlGenerator.GetCommand(SelectExpression)
+        // EF7 uses QuerySqlGenerator.GetCommand(Expression)
         // See: https://github.com/dotnet/efcore/blob/3f82c2b0af132b7019f6bd8b32c2709469b0ffae/src/EFCore.Relational/Query/QuerySqlGenerator.cs#L67
         var methodInfo = typeof(QuerySqlGenerator)
             .GetMethod(nameof(QuerySqlGenerator.GetCommand), new[] { typeof(Expression) });

--- a/EFCore.BulkExtensions/IQueryableExtensions.cs
+++ b/EFCore.BulkExtensions/IQueryableExtensions.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using EFCore.BulkExtensions.Helpers;
 
 namespace EFCore.BulkExtensions;
 
@@ -50,7 +51,8 @@ public static class IQueryableExtensions
             string querySqlGeneratorFactoryText = "_querySqlGeneratorFactory";
             SelectExpression selectExpression = enumerator.Private<SelectExpression>(selectExpressionText) ?? throw new InvalidOperationException($"{cannotGetText} {selectExpressionText}");
             IQuerySqlGeneratorFactory factory = enumerator.Private<IQuerySqlGeneratorFactory>(querySqlGeneratorFactoryText) ?? throw new InvalidOperationException($"{cannotGetText} {querySqlGeneratorFactoryText}");
-            command = factory.Create().GetCommand(selectExpression);
+            var querySqlGenerator = factory.Create();
+            command = QuerySqlGeneratorHelpers.GetCommand(querySqlGenerator, selectExpression);
         }
         string sql = command.CommandText;
 


### PR DESCRIPTION
Should help with #993  

As discussed in #1018 when using EF7 the signature of `QuerySqlGenerator.GetCommand` has changed. 
This prevents using EF7. 

![image](https://user-images.githubusercontent.com/8641495/209362453-c21b5657-404e-46b6-9be4-1636552ce4f9.png)

This PR introduces a helper class that finds the EF7 `GetCommand` via reflection and caches it as a delegate. This will then be used instead of a direct call to `GetCommand`. Under EF6 the direct call will be used as it always has.

I've tested this with NET6 EF6 and NET7 EF7. 
The code is simple and should not pose great risk.

This does impose a small performance hit, regarding the nullcheck and calling a delegate in EF7,
but these are so small it outweighs the benefit.


