### PR TITLE
Fix Sql Lite command when property of a column is camelcase but the mapping is uppercase

### DIFF
--- a/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SQLite/SqLiteAdapter.cs
@@ -377,7 +377,7 @@ public class SqliteOperationsAdapter : ISqlOperationsAdapter
 
             if (propertyEntityType != null)
             {
-                string? columnName = propertyEntityType.GetColumnName(tableInfo.ObjectIdentifier);
+                string? columnName = propertyEntityType.Name;
                 var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
 
                 //SqliteType(CpropertyType.Name): Text(String, Decimal, DateTime); Integer(Int16, Int32, Int64) Real(Float, Double) Blob(Guid)


### PR DESCRIPTION
Hi,
I have found a possible bug for SqlLite. In my case my model of the entities of EF are camelcase, but the mapping is upercase.

Example:
    public partial class Actor
    {
        public int Id { get; set; }
    }
Mapping
        public override void Configure(EntityTypeBuilder<Actor> builder)
        {
            builder.ToTable("ACTORS", schema);

            builder.HasKey(p => new { p.Id });

            // Properties:

            builder.Property(p => p.Id)
                     .HasColumnName("ID")
                     .IsRequired()
                     .ValueGeneratedOnAdd();
}

With this configuration there is a mistmatch with the bulkcommands query and the parameters:
![image](https://user-images.githubusercontent.com/33250761/216257441-60f3bda6-3b58-4e15-a2e6-6ce69be6ddbb.png)

The command query is like this:
UPDATE [ACTORS] SET [ID] = @Id  WHERE [ID] = @Id;

The command parameters are Uppercase, but must be the original name of the property Id instead of ID.

With this simple change now it create the good command and the good paratemer names.
