### PR TITLE
Fix some cases when IgnoreGlobalQueryFilters is true (SetOutputIdentity)

### DIFF
--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -1209,6 +1209,10 @@ public class TableInfo
         {
             expression = Expression.Call(typeof(EntityFrameworkQueryableExtensions), "AsNoTracking", new Type[] { entityType }, expression);
         }
+        if (BulkConfig.IgnoreGlobalQueryFilters)
+        {
+            expression = Expression.Call(typeof(EntityFrameworkQueryableExtensions), "IgnoreQueryFilters", new Type[] { entityType }, expression);
+        }
         expression = ordered ? OrderBy(entityType, expression, PrimaryKeysPropertyColumnNameDict.Select(a => a.Key).ToList()) : expression;
         return Expression.Lambda<Func<DbContext, IEnumerable>>(expression, parameter);
 


### PR DESCRIPTION
In my case (SqlServer), when this change resolve a bug when has a GlobalQueryFilter and use BulkInsert with SetOutputIdentity.


Maybe resolve some open issues about SetOutputIdentity (including for another database #793)