### PR TITLE
Get Postgresql default schema from Search Path

### DIFF
--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Npgsql;
 
 namespace EFCore.BulkExtensions;
 
@@ -169,7 +170,15 @@ public class TableInfo
         if (isSqlServer)
             defaultSchema = "dbo";
         if (isNpgsql)
+        {            
             defaultSchema = "public";
+
+            var csb = new NpgsqlConnectionStringBuilder(context.Database.GetConnectionString());
+            if (!string.IsNullOrWhiteSpace(csb.SearchPath))
+            {
+                defaultSchema = csb.SearchPath.Split(',')[0];
+            }
+        }
 
         string? customSchema = null;
         string? customTableName = null;


### PR DESCRIPTION
Fix for Postgresql schemas, when schema is set in a Search Path parameter of a connection string.
Without this the Search Path is ignored (we set it at runtime - multitenant app) and defaults to "public", which in our case is wrong.

https://www.npgsql.org/doc/connection-string-parameters.html#misc

Examples:

| Connection String | Default Schema |
| --- | --- |
| `Host=myserver;Username=mylogin;Password=mypass;Database=mydatabase;SearchPath=myschema` | `myschema` |
| `Host=myserver;Username=mylogin;Password=mypass;Database=mydatabase;SearchPath=myschema,public` | `myschema` |
| `Host=myserver;Username=mylogin;Password=mypass;Database=mydatabase` | `public` |
