### PR TITLE
Fix SetSynchronizeSoftDelete option

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -694,6 +694,18 @@ public class EFCoreBulkTest
         var list = context.Items.Take(2).ToList();
         Assert.True(list[0].Quantity != 0);
         Assert.True(list[1].Quantity == 0);
+
+        // TEST Alias
+        context.Entries.Add(new Entry { Name = "Entry_InsertOrUpdateOrDelete" });
+        context.SaveChanges();
+
+        int entriesCount = context.Entries.Count();
+        
+        bulkConfigSoftDel.SetSynchronizeSoftDelete<Entry>(a => new Entry { Name = "Entry_InsertOrUpdateOrDelete_Deleted" });
+        context.BulkInsertOrUpdateOrDelete(new List<Entry> { new Entry { Name = "Entry_InsertOrUpdateOrDelete_2" } }, bulkConfigSoftDel);
+
+        Assert.Equal(entriesCount + 1,  context.Entries.Count());
+        Assert.True(context.Entries.Any(e => e.Name == "Entry_InsertOrUpdateOrDelete_Deleted"));
     }
 
     private static void RunUpdate(bool isBulk, SqlType sqlType)

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -279,7 +279,7 @@ public class EFCoreBulkTestAsync
             await context.BulkInsertOrUpdateOrDeleteAsync(entities, bulkConfig);
             Assert.Equal(0, bulkConfig.StatsInfo?.StatsNumberInserted);
             Assert.Equal(EntitiesNumber / 2, bulkConfig.StatsInfo?.StatsNumberUpdated);
-            Assert.Equal((EntitiesNumber / 2) -1, bulkConfig.StatsInfo?.StatsNumberDeleted);
+            Assert.Equal((EntitiesNumber / 2) - 1, bulkConfig.StatsInfo?.StatsNumberDeleted);
         }
         else
         {
@@ -304,11 +304,23 @@ public class EFCoreBulkTestAsync
 
         var bulkConfigSoftDel = new BulkConfig();
         bulkConfigSoftDel.SetSynchronizeSoftDelete<Item>(a => new Item { Quantity = 0 }); // Instead of Deleting from DB it updates Quantity to 0 (usual usecase would be: IsDeleted to True)
-        context.BulkInsertOrUpdateOrDelete(new List<Item> { entities[1] }, bulkConfigSoftDel);
+        await context.BulkInsertOrUpdateOrDeleteAsync(new List<Item> { entities[1] }, bulkConfigSoftDel);
 
         var list = await context.Items.Take(2).ToListAsync();
         Assert.True(list[0].Quantity != 0);
         Assert.True(list[1].Quantity == 0);
+
+        // TEST Alias
+        await context.Entries.AddAsync(new Entry { Name = "Entry_InsertOrUpdateOrDelete" });
+        await context.SaveChangesAsync();
+
+        int entriesCount = await contextRead.Entries.CountAsync();
+        
+        bulkConfigSoftDel.SetSynchronizeSoftDelete<Entry>(a => new Entry { Name = "Entry_InsertOrUpdateOrDelete_Deleted" });
+        await context.BulkInsertOrUpdateOrDeleteAsync(new List<Entry> { new Entry { Name = "Entry_InsertOrUpdateOrDelete_2" } }, bulkConfigSoftDel);
+
+        Assert.Equal(entriesCount + 1, await contextRead.Entries.CountAsync());
+        Assert.True(await context.Entries.AnyAsync(e => e.Name == "Entry_InsertOrUpdateOrDelete_Deleted"));
     }
 
     private static async Task RunUpdateAsync(bool isBulk, SqlType sqlType)
@@ -358,7 +370,7 @@ public class EFCoreBulkTestAsync
             entities.Add(new Item { Name = "name " + i });
         }
 
-        var bulkConfig = new BulkConfig { UpdateByProperties = new List<string> { nameof(Item.Name) }};
+        var bulkConfig = new BulkConfig { UpdateByProperties = new List<string> { nameof(Item.Name) } };
         await context.BulkReadAsync(entities, bulkConfig).ConfigureAwait(false);
 
         Assert.Equal(1, entities[0].ItemId);

--- a/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
@@ -399,8 +399,10 @@ public abstract class SqlQueryBuilder
                 var querable = context.Set<T>().IgnoreQueryFilters().IgnoreAutoIncludes();
                 var expression = (Expression<Func<T, T>>)tableInfo.BulkConfig.SynchronizeSoftDelete;
                 var (sqlOriginal, sqlParameters) = BatchUtil.GetSqlUpdate(querable, context, typeof(T), expression);
+                var databaseType = SqlAdaptersMapping.GetDatabaseType();
+                var (tableAlias, _) = SqlAdaptersMapping.GetAdapterDialect().GetBatchSqlReformatTableAliasAndTopStatement(sqlOriginal, databaseType);
 
-                var sql = sqlOriginal.Replace("[i]", "T");
+                var sql = sqlOriginal.Replace($"[{tableAlias}]", "T");
                 int indexFrom = sql.IndexOf(".") - 1;
                 int indexTo = sql.IndexOf("\r\n") - indexFrom;
                 softDeleteAssignment = sql.Substring(indexFrom, indexTo);


### PR DESCRIPTION
When using SetSynchronizeSoftDelete option the query fail with the following message.
> Incorrect syntax near ']'

After dumping the sql and locating the place in the code where the problematic statement was build, it appear that there is an hardcoded 'i' value instead of a table alias.
https://github.com/borisdj/EFCore.BulkExtensions/blob/b622a0c1fac2002a8cc62b9c7847762d0871e901/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs#L403

So if the generated alias of the entity is 'i' (like in the current unit test) it's works.
But if not the replace fail and an invalid sql statement is generated.

This fix replace the hardcoded value with the correct table alias for the update statement used when the SetSynchronizeSoftDelete is defined fixing the issue.