### PR TITLE
Fix soft delete feature on linux by using cross-platform NewLine

### DIFF
--- a/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
@@ -402,7 +402,7 @@ public abstract class SqlQueryBuilder
 
                 var sql = sqlOriginal.Replace("[i]", "T");
                 int indexFrom = sql.IndexOf(".") - 1;
-                int indexTo = sql.IndexOf("\r\n") - indexFrom;
+                int indexTo = sql.IndexOf(Environment.NewLine) - indexFrom;
                 softDeleteAssignment = sql.Substring(indexFrom, indexTo);
                 softDeleteAssignment = softDeleteAssignment.TrimEnd();
                 parameters.AddRange(sqlParameters);


### PR DESCRIPTION
Found another bug in the soft delete feature.
The newline \r\n was hardcoded in the code.
It is problematic as it's platform dependent so it currently only works on Windows.
Replaced it with Environment.Newline to fix that.