### PR TITLE
Proposed fix to SaveChangesAsync entity ordering for deletions

### DIFF
--- a/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
+++ b/EFCore.BulkExtensions/DbContextBulkTransactionSaveChanges.cs
@@ -71,7 +71,7 @@ internal static class DbContextBulkTransactionSaveChanges
         var deleted = entriesGroupedByEntity.Where(x => x.State == EntityState.Deleted);
         var deletedLookup = deleted.ToLookup(x => x.EntityType);
 #if NET8_0
-        var sortedDeleted = deleted.OrderTopologicallyBy(g => getFks(g.EntityType).SelectMany(x => deletedLookup[x]).Reverse());
+        var sortedDeleted = deleted.OrderTopologicallyBy(g => getFks(g.EntityType).SelectMany(x => deletedLookup[x])).Reverse();
 #else
         var sortedDeleted = deleted;
 #endif


### PR DESCRIPTION
Reverse deletion order of outer enumerable of entity groups rather than inner lists of entities when invoking BulkSaveChangesAsync.

#899 