### PR TITLE
PostgreSqlAdapter, correct columnType for decimal[]

### DIFF
--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -90,7 +90,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
                         columnType = "character";             // 'character' is like 'string'
                     else if (columnType.StartsWith("varchar"))
                         columnType = "varchar";
-                    else if (columnType.StartsWith("numeric"))
+                    else if (columnType.StartsWith("numeric") && columnType != "numeric[]")
                         columnType = "numeric";
 
                     if (columnType.StartsWith("timestamp(")) // timestamp(n) | len:12 // TEST: TimeStamp2PGTest


### PR DESCRIPTION
BulkInsert (PostgreSql) row with decimal[] column throws: System.InvalidCastException: 'Writing values of 'System.Decimal[]' is not supported for parameters having DataTypeName 'numeric'.'
Entity type to reproduce:
```
public class Row
{
    public int Id { get; set; }
    public required decimal[] Values { get; set; }
}
```