### PR TITLE
fix(postgre): correctly count number of constraints

### DIFF
--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
@@ -264,7 +264,7 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
         bool usePG_Catalog = true; // PG_Catalog used instead of Information_Schema
         if (usePG_Catalog)
         {
-            q = @"SELECT COUNT(*)
+            q = @"SELECT COUNT(distinct c.conname)
                   FROM pg_catalog.pg_namespace nr,
                       pg_catalog.pg_class r,
                       pg_catalog.pg_attribute a,


### PR DESCRIPTION
When multiple fields are provided the existing query gives the count which is greater than 1. This later causes a new constraint creation. This in its' turn cannot be run in concurrent environment.