### PR TITLE
Correct bulk operation on Sqlite Geometry types

### DIFF
--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -853,7 +853,8 @@ public class EFCoreBulkTestAtypical
                     Street = "Some Street nn",
                     LocationGeography = new Point(52, 13),
                     LocationGeometry = new Point(52, 13),
-                    GeoLine = new LineString(new List<Coordinate> { new Coordinate(52, 13), new Coordinate(50, 12) }.ToArray())
+                    GeoLine = new LineString(new List<Coordinate> { new Coordinate(52, 13), new Coordinate(50, 12) }.ToArray()) { SRID = 4326 },
+                    GeoPoint = new Point(52, 13) { SRID = 4326 }
                 }
             };
 

--- a/EFCore.BulkExtensions.Tests/TestContext.cs
+++ b/EFCore.BulkExtensions.Tests/TestContext.cs
@@ -203,7 +203,13 @@ public class TestContext : DbContext
 
             modelBuilder.Entity<ItemHistory>().ToTable(nameof(ItemHistory));
 
-            modelBuilder.Entity<Address>().Ignore(p => p.GeoLine); // throws: SQLite Error 19: 'Address.GeoLine violates Geometry constraint [geom-type or SRID 
+            modelBuilder.Entity<Address>()
+                .Property(p => p.GeoLine)
+                .HasSrid(4326);
+
+            modelBuilder.Entity<Address>()
+                .Property(p => p.GeoPoint)
+                .HasSrid(4326);
         }
 
         if (Database.IsMySql())
@@ -594,6 +600,7 @@ public class Address
     public Geometry LocationGeography { get; set; } = null!;
     public Geometry LocationGeometry { get; set; } = null!;
     public LineString? GeoLine { get; set; }
+    public Point? GeoPoint { get; set; }
 }
 
 public class Category


### PR DESCRIPTION
Hi,

Issue 1023 and 1214 are mentioned as fixed but it doesn't seems to be the case.

When inserting a point type with bulk insert the following exception is throw
>  No mapping exists from object type NetTopologySuite.Geometries.Point to a known managed provider native type.

This is because only Geometry and LineString types are handled by the [adapter](https://github.com/kvpt/EFCore.BulkExtensions/blob/7de0593127f779c6e3a928b6c7f74fa56f7457bf/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteAdapter.cs#L495).

A more robust approach is to use instead the Geometry type only and rely on polymorphism.
However this alone doesn't work, the error is now
> '<GeoColumn> violates Geometry constraint [geom-type or SRID not allowed]'

To solve this we have two things to do :
- The first is to the right ordinate in the writer, I reused the code from EfCore [here](https://github.com/dotnet/efcore/blob/c3d3dc69f20c91e5f31aac1a126b375f8fccc5cf/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs#L131).
- The second is to use the same SRID value between the one declared in the context and the one of the geometry value
The previous code used the SRID defined in the BulkOperation configuration but I don't think it's the right think to do here because if the SRID is not defined in the context (and so in the database) the SRID need to be 0 and not the SRID from the BulkOperation. Another issue is that in an entity two geometry column can have different SRID is highly unlikely but technically possible.
The right thing to do is either to do nothing and only use the one provided at the geometry creation or to get the one defined in the Context. I tried to do this by using the GetSrid method on the property but I get nothing.
So I choose to fallback on the "passthrough" way and ignore the value defined in the BulkOperation configuration.

Fix #1203
Fix #1214