### PR TITLE
Fix for bulk insert using include graph

### DIFF
--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -9,7 +9,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
-using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -1081,6 +1080,15 @@ public class TableInfo
     {
         var identifierPropertyName = IdentityColumnName != null ? OutputPropertyColumnNamesDict.SingleOrDefault(a => a.Value == IdentityColumnName).Key // it Identity autoincrement 
                                                                 : PrimaryKeysPropertyColumnNameDict.FirstOrDefault().Key;                               // or PK with default sql value
+
+        var fastProperty = FastPropertyDict[identifierPropertyName];
+
+        if (fastProperty.Property.PropertyType == typeof(string) ||
+            fastProperty.Property.PropertyType == typeof(Guid))
+        {
+            entities = entities.OrderBy(p => fastProperty.Property!.GetValue(p, null)).ToList();
+            entitiesWithOutputIdentity = entitiesWithOutputIdentity.OrderBy(p => fastProperty.Property!.GetValue(p, null)).ToList();
+        }
 
         if (BulkConfig.PreserveInsertOrder) // Updates Db changed Columns in entityList
         {


### PR DESCRIPTION
Fix for bulk insert using include graph when `PKs` are `string` or `Guid`.

This PR addresses the issue #1314 

When the parent object has a `string` or `Guid` `PK` the order of the entities in the `entitiesWithOutputIdentity` variable is different as the order when the entities were inserted. Because the `ORDER BY` on the DB behaves different then the `OrderBy()` in C# we have to order both variables `entitiesWithOutputIdentity` and `entities` by the `PK`. With this fix the child entites are assigned with the correct `PK`.