### PR TITLE
Overhaul DbParameter handling and dependencies trimming in provider specific projects

### DIFF
--- a/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
+++ b/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.MySql/EFCore.BulkExtensions.MySql.csproj
@@ -28,9 +28,8 @@
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.HierarchyId" Version="8.0.4" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.4" />
-	<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="NetTopologySuite" Version="2.5.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
 	<PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />
 	<PackageReference Include="StrongNamer" Version="0.2.5" />
   </ItemGroup>

--- a/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.PostgreSql/EFCore.BulkExtensions.PostgreSql.csproj
+++ b/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.PostgreSql/EFCore.BulkExtensions.PostgreSql.csproj
@@ -28,7 +28,6 @@
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
 	<PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />

--- a/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.Sqlite/EFCore.BulkExtensions.Sqlite.csproj
+++ b/EFCore.BulkExtensions.PerProvider/EFCore.BulkExtensions.Sqlite/EFCore.BulkExtensions.Sqlite.csproj
@@ -28,7 +28,6 @@
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.4" />
 	<PackageReference Include="NetTopologySuite.IO.SpatiaLite" Version="2.0.0" />

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -609,7 +609,7 @@ public class EFCoreBulkTest
             var bulkConfig = new BulkConfig() {
                 SetOutputIdentity = true,
                 CalculateStats = true,
-                SqlBulkCopyOptions = Microsoft.Data.SqlClient.SqlBulkCopyOptions.KeepIdentity
+                SqlBulkCopyOptions = SqlBulkCopyOptions.KeepIdentity
             };
             context.BulkInsertOrUpdate(entities, bulkConfig, (a) => WriteProgress(a));
             if (sqlType == SqlType.SqlServer)

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -227,7 +227,7 @@ public class EFCoreBulkTestAsync
             {
                 SetOutputIdentity = true,
                 CalculateStats = true,
-                SqlBulkCopyOptions = Microsoft.Data.SqlClient.SqlBulkCopyOptions.KeepIdentity
+                SqlBulkCopyOptions = SqlBulkCopyOptions.KeepIdentity
             };
             await context.BulkInsertOrUpdateAsync(entities, bulkConfig);
             if (sqlType == SqlType.SqlServer)

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAtypical.cs
@@ -1071,7 +1071,7 @@ public class EFCoreBulkTestAtypical
 
         var bulkConfigBase = new BulkConfig
         {
-            SqlBulkCopyOptions = Microsoft.Data.SqlClient.SqlBulkCopyOptions.KeepIdentity, // OPTION 1. - to ensure insert order is kept the same since SqlBulkCopy does not guarantee it.
+            SqlBulkCopyOptions = SqlBulkCopyOptions.KeepIdentity, // OPTION 1. - to ensure insert order is kept the same since SqlBulkCopy does not guarantee it.
             PropertiesToInclude = new List<string>
                 {
                     nameof(LogPersonReport.LogId),

--- a/EFCore.BulkExtensions/Batch/BatchUpdateCreateBodyData.cs
+++ b/EFCore.BulkExtensions/Batch/BatchUpdateCreateBodyData.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
@@ -30,7 +31,7 @@ public class BatchUpdateCreateBodyData
     public BatchUpdateCreateBodyData(
         string baseSql,
         DbContext dbContext,
-        IEnumerable<object> innerParameters,
+        IEnumerable<DbParameter> innerParameters,
         IQueryable query,
         Type rootType,
         string tableAlias,
@@ -53,7 +54,7 @@ public class BatchUpdateCreateBodyData
         var tableInfo = TableInfo.CreateInstance(dbContext, rootType, Array.Empty<object>(), OperationType.Read, _tableInfoBulkConfig);
         _tableInfoLookup.Add(rootType, tableInfo);
 
-        SqlParameters = new List<object>(innerParameters);
+        SqlParameters = new List<DbParameter>(innerParameters);
 
         foreach (Match match in BatchUtil.TableAliasPattern.Matches(baseSql))
         {
@@ -68,7 +69,7 @@ public class BatchUpdateCreateBodyData
     public IQueryable Query { get; }
     public string? RootInstanceParameterName { get; }
     public Type RootType { get; }
-    public List<object> SqlParameters { get; }
+    public List<DbParameter> SqlParameters { get; }
     public string TableAlias { get; }
     public List<string> TableAliasesInUse { get; }
     public StringBuilder UpdateColumnsSql { get; }

--- a/EFCore.BulkExtensions/Batch/IQueryableBatchExtensions.cs
+++ b/EFCore.BulkExtensions/Batch/IQueryableBatchExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
@@ -40,7 +41,7 @@ public static class IQueryableBatchExtensions
         return await context.Database.ExecuteSqlRawAsync(sql, sqlParameters, cancellationToken).ConfigureAwait(false);
     }
 
-    private static (DbContext, string, List<object>) GetBatchDeleteArguments(IQueryable query)
+    private static (DbContext, string, List<DbParameter>) GetBatchDeleteArguments(IQueryable query)
     {
         var context = BatchUtil.GetDbContext(query);
         if (context is null)
@@ -115,7 +116,7 @@ public static class IQueryableBatchExtensions
         return await context.Database.ExecuteSqlRawAsync(sql, sqlParameters, cancellationToken).ConfigureAwait(false);
     }
 
-    private static (DbContext, string, List<object>) GetBatchUpdateArguments<T>(IQueryable<T> query, object? updateValues = null, List<string>? updateColumns = null, Expression<Func<T, T>>? updateExpression = null, Type? type = null) where T : class
+    private static (DbContext, string, List<DbParameter>) GetBatchUpdateArguments<T>(IQueryable<T> query, object? updateValues = null, List<string>? updateColumns = null, Expression<Func<T, T>>? updateExpression = null, Type? type = null) where T : class
     {
         type ??= typeof(T);
         var context = BatchUtil.GetDbContext(query);

--- a/EFCore.BulkExtensions/BulkConfig.cs
+++ b/EFCore.BulkExtensions/BulkConfig.cs
@@ -1,4 +1,3 @@
-using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -310,7 +309,7 @@ public class BulkConfig
     /// <value>
     ///     <c>Default, KeepIdentity, CheckConstraints, TableLock, KeepNulls, FireTriggers, UseInternalTransaction</c>
     /// </value>
-    public Microsoft.Data.SqlClient.SqlBulkCopyOptions SqlBulkCopyOptions { get; set; } // is superset of System.Data.SqlClient.SqlBulkCopyOptions, gets converted to the desired type
+    public SqlBulkCopyOptions SqlBulkCopyOptions { get; set; } // is superset of System.Data.SqlClient.SqlBulkCopyOptions, gets converted to the desired type
 
     /// <summary>
     ///     List of column order hints for improving performance.
@@ -399,4 +398,83 @@ public class TimeStampInfo
     /// Output the entities.
     /// </summary>
     public List<object> EntitiesOutput { get; set; } = null!;
+}
+
+/// <summary>
+/// Bitwise flag that specifies one or more options to use with an instance of <see cref="T:Microsoft.Data.SqlClient.SqlBulkCopy"/>.
+/// </summary>
+[Flags]
+public enum SqlBulkCopyOptions
+{
+    /// <summary>
+    /// Use the default values for all options.
+    /// </summary>
+    Default = 0,
+    /// <summary>
+    /// Preserve source identity values. When not specified, identity values are assigned by the destination.
+    /// </summary>
+    KeepIdentity = 1 << 0,
+    /// <summary>
+    /// Check constraints while data is being inserted. By default, constraints are not checked.
+    /// </summary>
+    CheckConstraints = 1 << 1,
+    /// <summary>
+    /// Obtain a bulk update lock for the duration of the bulk copy operation. When not specified, row locks are used.
+    /// </summary>
+    TableLock = 1 << 2,
+    /// <summary>
+    /// Preserve null values in the destination table regardless of the settings for default values.
+    /// When not specified, null values are replaced by default values where applicable.
+    /// </summary>
+    KeepNulls = 1 << 3,
+    /// <summary>
+    /// When specified, cause the server to fire the insert triggers for the rows being inserted into the database.
+    /// </summary>
+    FireTriggers = 1 << 4,
+    /// <summary>
+    /// When specified, each batch of the bulk-copy operation will occur within a transaction.
+    /// If you indicate this option and also provide a <see cref="T:Microsoft.Data.SqlClient.SqlTransaction" />object to the constructor,
+    /// an <see cref="T:System.ArgumentException" /> occurs.
+    /// </summary>
+    UseInternalTransaction = 1 << 5,
+    /// <summary>
+    /// When specified, **AllowEncryptedValueModifications** enables bulk copying of encrypted data between tables or databases, without decrypting the data.
+    /// </summary>
+    AllowEncryptedValueModifications = 1 << 6
+}
+
+/// <summary>
+/// Defines the sort order for a column in a <see cref="T:Microsoft.Data.SqlClient.SqlBulkCopy" /> instance's destination table,
+/// according to the clustered index on the table.
+/// </summary>
+public class SqlBulkCopyColumnOrderHint
+{
+    /// <summary>
+    /// The name of the destination column within the destination table.
+    /// </summary>
+    public required string Column { get; set; }
+
+    /// <summary>
+    /// The sort order of the corresponding destination column.
+    /// </summary>
+    public SortOrder SortOrder { get; set; } = SortOrder.Unspecified;
+}
+
+/// <summary>
+/// Specifies how rows of data are sorted.
+/// </summary>
+public enum SortOrder
+{
+    /// <summary>
+    /// The default. No sort order is specified.
+    /// </summary>
+    Unspecified = -1,
+    /// <summary>
+    /// Rows are sorted in ascending order.
+    /// </summary>
+    Ascending = 0,
+    /// <summary>
+    /// Rows are sorted in descending order.
+    /// </summary>
+    Descending = 1
 }

--- a/EFCore.BulkExtensions/SqlAdapters/ISqlDialect.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/ISqlDialect.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq.Expressions;
 
 namespace EFCore.BulkExtensions.SqlAdapters;
@@ -27,7 +28,7 @@ public interface IQueryBuilderSpecialization
     /// </summary>
     /// <param name="context"></param>
     /// <param name="sqlParameters"></param>
-    List<object> ReloadSqlParameters(DbContext context, List<object> sqlParameters);
+    List<DbParameter> ReloadSqlParameters(DbContext context, List<DbParameter> sqlParameters);
 
     /// <summary>
     /// Returns the binary expression add operation

--- a/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlAdapter.cs
@@ -2,8 +2,6 @@
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using MySqlConnector;
-using NetTopologySuite.Algorithm;
-using NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -15,6 +13,7 @@ using System.Reflection;
 using System.Security.AccessControl;
 using System.Threading;
 using System.Threading.Tasks;
+using NetTopologySuite.Geometries;
 
 namespace EFCore.BulkExtensions.SqlAdapters.MySql;
 
@@ -496,10 +495,6 @@ public class MySqlAdapter : ISqlOperationsAdapter
                         throw new InvalidOperationException("OnCompare properties Config can not be set for Entity with Spatial types like 'Geometry'");
                     }
                 }
-                if (isMySql && (propertyType == typeof(HierarchyId) || propertyType.IsSubclassOf(typeof(HierarchyId))))
-                {
-                    propertyType = typeof(byte[]);
-                }
 
                 if (!columnsDict.ContainsKey(property.Name) && !hasDefaultVauleOnInsert)
                 {
@@ -528,11 +523,6 @@ public class MySqlAdapter : ISqlOperationsAdapter
                 }
 
                 if (propertyType == typeof(Geometry) && isMySql)
-                {
-                    propertyType = typeof(byte[]);
-                }
-
-                if (propertyType == typeof(HierarchyId) && isMySql)
                 {
                     propertyType = typeof(byte[]);
                 }
@@ -625,11 +615,6 @@ public class MySqlAdapter : ISqlOperationsAdapter
                     propertyType = typeof(byte[]);
                 }
 
-                if (isMySql && (propertyType == typeof(HierarchyId) || propertyType.IsSubclassOf(typeof(HierarchyId))))
-                {
-                    propertyType = typeof(byte[]);
-                }
-
                 dataTable.Columns.Add(columnName, propertyType);
                 columnsDict.Add(shadowProperty.Name, null);
             }
@@ -696,14 +681,6 @@ public class MySqlAdapter : ISqlOperationsAdapter
                     propertyValue = MySqlGeometry.FromWkb(geometryValue.SRID, wkb);
                 }
 
-                if (propertyValue is HierarchyId hierarchyValue && isMySql)
-                {
-                    using MemoryStream memStream = new();
-                    using BinaryWriter binWriter = new(memStream);
-
-                    //hierarchyValue.Write(binWriter); // removed as of EF8 (throws: Error CS1061  'HierarchyId' does not contain a definition for 'Write' and no accessible extension method 'Write' accepting a first argument of type 'HierarchyId' could be found.
-                    propertyValue = memStream.ToArray();
-                }
                 if (entityPropertiesDict.ContainsKey(property.Name) && !hasDefaultVauleOnInsert)
                 {
                     columnsDict[property.Name] = propertyValue;

--- a/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/MySql/MySqlQueryBuilder.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.Data.SqlClient;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using MySqlConnector;
 
 namespace EFCore.BulkExtensions.SqlAdapters.MySql;
 
@@ -311,26 +313,28 @@ public class MySqlQueryBuilder : SqlQueryBuilder
         return q;
     }
 
-    /// <summary>
-    /// Returns a DbParameters intanced per provider
-    /// </summary>
-    /// <param name="sqlParameter"></param>
-    /// <returns></returns>
-    public override object CreateParameter(SqlParameter sqlParameter)
+    /// <inheritdoc/>
+    public override DbParameter CreateParameter(string parameterName, object? parameterValue = null)
     {
-        return new MySqlConnector.MySqlParameter(sqlParameter.ParameterName, sqlParameter.Value);
+        return new MySqlParameter(parameterName, parameterValue);
     }
 
     /// <inheritdoc/>
-    public override object Dbtype()
+    public override DbCommand CreateCommand()
     {
-        throw new NotImplementedException();
+        return new MySqlCommand();
     }
 
     /// <inheritdoc/>
-    public override void SetDbTypeParam(object npgsqlParameter, object dbType)
+    public override DbType Dbtype()
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
+    }
+
+    /// <inheritdoc/>
+    public override void SetDbTypeParam(DbParameter parameter, DbType dbType)
+    {
+        throw new NotSupportedException();
     }
 
     private static string Md5Hash(string value)

--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using System;
 using System.Collections.Generic;
@@ -35,7 +34,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     protected static async Task InsertAsync<T>(DbContext context, IEnumerable<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync,
         CancellationToken cancellationToken)
     {
-        NpgsqlConnection? connection = (NpgsqlConnection?)SqlAdaptersMapping.DbServer!.DbConnection; // TODO refactor
+        NpgsqlConnection? connection = (NpgsqlConnection?)SqlAdaptersMapping.DbServer.DbConnection; // TODO refactor
         bool closeConnectionInternally = false;
         if (connection == null)
         {

--- a/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Data.SqlClient;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
+using Npgsql;
 
 namespace EFCore.BulkExtensions.SqlAdapters.PostgreSql;
 
@@ -434,14 +436,16 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
         return sql;
     }
 
-    /// <summary>
-    /// Returns a DbParameters intanced per provider
-    /// </summary>
-    /// <param name="sqlParameter"></param>
-    /// <returns></returns>
-    public override object CreateParameter(SqlParameter sqlParameter)
+    /// <inheritdoc/>
+    public override DbParameter CreateParameter(string parameterName, object? parameterValue = null)
     {
-        return new Npgsql.NpgsqlParameter(sqlParameter.ParameterName, sqlParameter.Value);
+        return new NpgsqlParameter(parameterName, parameterValue);
+    }
+
+    /// <inheritdoc/>
+    public override DbCommand CreateCommand()
+    {
+        return new NpgsqlCommand();
     }
 
     /// <summary>
@@ -459,17 +463,17 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
     /// </summary>
     /// <returns></returns>
     /// <exception cref="NotImplementedException"></exception>
-    public override object Dbtype()
+    public override DbType Dbtype()
     {
-        return NpgsqlTypes.NpgsqlDbType.Jsonb;
+        return (DbType)NpgsqlTypes.NpgsqlDbType.Jsonb;
     }
 
     /// <summary>
     /// Returns void. Throws <see cref="NotImplementedException"/> for anothers providers
     /// </summary>
     /// <exception cref="NotImplementedException"></exception>
-    public override void SetDbTypeParam(object npgsqlParameter, object dbType)
+    public override void SetDbTypeParam(DbParameter parameter, DbType dbType)
     {
-        ((Npgsql.NpgsqlParameter)npgsqlParameter).NpgsqlDbType = (NpgsqlTypes.NpgsqlDbType)dbType;
+        ((NpgsqlParameter)parameter).NpgsqlDbType = (NpgsqlTypes.NpgsqlDbType)dbType;
     }
 }

--- a/EFCore.BulkExtensions/SqlAdapters/SqlAdaptersMapping.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlAdaptersMapping.cs
@@ -40,7 +40,7 @@ public static class SqlAdaptersMapping
     /// <summary>
     /// Contains a list of methods to generate Adapters and helpers instances
     /// </summary>
-    public static IDbServer? DbServer {
+    public static IDbServer DbServer {
         get
         {
             // Context.Database. methods:
@@ -92,7 +92,7 @@ public static class SqlAdaptersMapping
                 var dbServerInstance = Activator.CreateInstance(dbServerType ?? typeof(int));
                 _dbServer = dbServerInstance as IDbServer;
             }
-            return _dbServer;
+            return _dbServer ?? throw new InvalidOperationException("Failed to create DbServer");
         }
     }
 
@@ -104,7 +104,7 @@ public static class SqlAdaptersMapping
     /// <returns></returns>
     public static ISqlOperationsAdapter CreateBulkOperationsAdapter()
     {
-        return DbServer!.Adapter;
+        return DbServer.Adapter;
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public static class SqlAdaptersMapping
     /// <returns></returns>
     public static IQueryBuilderSpecialization GetAdapterDialect()
     {
-        return DbServer!.Dialect;
+        return DbServer.Dialect;
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public static class SqlAdaptersMapping
     /// <returns></returns>
     public static SqlType GetDatabaseType()
     {
-        return DbServer!.Type;
+        return DbServer.Type;
     }
 
     /// <summary>
@@ -131,6 +131,6 @@ public static class SqlAdaptersMapping
     /// <returns></returns>
     public static SqlQueryBuilder GetQueryBuilder()
     {
-        return DbServer!.QueryBuilder;
+        return DbServer.QueryBuilder;
     }
 }

--- a/EFCore.BulkExtensions/SqlAdapters/SqlDefaultDialect.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlDefaultDialect.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Linq.Expressions;
 
 namespace EFCore.BulkExtensions.SqlAdapters;
@@ -12,12 +13,12 @@ public class SqlDefaultDialect : IQueryBuilderSpecialization
     private static readonly int SelectStatementLength = "SELECT".Length;
 
     /// <inheritdoc/>
-    public virtual List<object> ReloadSqlParameters(DbContext context, List<object> sqlParameters)
+    public virtual List<DbParameter> ReloadSqlParameters(DbContext context, List<DbParameter> sqlParameters)
     {
-        var sqlParametersReloaded = new List<object>();
+        var sqlParametersReloaded = new List<DbParameter>();
         foreach (var parameter in sqlParameters)
         {
-            var sqlParameter = (IDbDataParameter)parameter;
+            var sqlParameter = parameter;
 
             try
             {

--- a/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlQueryBuilder.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Data.SqlClient;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -20,23 +21,26 @@ public abstract class SqlQueryBuilder
     public abstract string RestructureForBatch(string sql, bool isDelete = false);
 
     /// <summary>
-    /// Returns a DbParameters intanced per provider
+    /// Returns a DbParameter instantiated per provider
     /// </summary>
-    /// <param name="sqlParameter"></param>
-    /// <returns></returns>
-    public abstract object CreateParameter(SqlParameter sqlParameter);
+    public abstract DbParameter CreateParameter(string parameterName, object? parameterValue = null);
+
+    /// <summary>
+    /// Returns a DbCommand instantiated per provider
+    /// </summary>
+    public abstract DbCommand CreateCommand();
 
     /// <summary>
     /// Returns NpgsqlDbType for PostgreSql parameters. Throws <see cref="NotImplementedException"/> for anothers providers
     /// </summary>
     /// <returns></returns>
-    public abstract object Dbtype();
+    public abstract DbType Dbtype();
 
     /// <summary>
     /// Returns void. Throws <see cref="NotImplementedException"/> for anothers providers
     /// </summary>
     /// <exception cref="NotImplementedException"></exception>
-    public abstract void SetDbTypeParam(object npgsqlParameter, object dbType);
+    public abstract void SetDbTypeParam(DbParameter parameter, DbType dbType);
 
     /// <summary>
     /// Generates SQL query to select output from a table

--- a/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerAdapter.cs
@@ -392,11 +392,11 @@ public class SqlServerAdapter : ISqlOperationsAdapter
     private static SqlBulkCopy GetSqlBulkCopy(SqlConnection sqlConnection, IDbContextTransaction? transaction, BulkConfig config)
     {
         var sqlTransaction = transaction == null ? null : (SqlTransaction)transaction.GetUnderlyingTransaction(config);
-        var sqlBulkCopy = new SqlBulkCopy(sqlConnection, config.SqlBulkCopyOptions, sqlTransaction);
+        var sqlBulkCopy = new SqlBulkCopy(sqlConnection, (Microsoft.Data.SqlClient.SqlBulkCopyOptions)config.SqlBulkCopyOptions, sqlTransaction);
         if (config.SqlBulkCopyColumnOrderHints != null)
         {
             foreach(var hint in config.SqlBulkCopyColumnOrderHints)
-                sqlBulkCopy.ColumnOrderHints.Add(hint);
+                sqlBulkCopy.ColumnOrderHints.Add(new Microsoft.Data.SqlClient.SqlBulkCopyColumnOrderHint(hint.Column, (Microsoft.Data.SqlClient.SortOrder)hint.SortOrder));
         }
         return sqlBulkCopy;
     }

--- a/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/SqlServer/SqlServerQueryBuilder.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Data.SqlClient;
-using System;
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
 
 namespace EFCore.BulkExtensions.SqlAdapters.SqlServer;
 
@@ -9,26 +11,32 @@ namespace EFCore.BulkExtensions.SqlAdapters.SqlServer;
 public class SqlServerQueryBuilder : SqlQueryBuilder
 {
     /// <inheritdoc/>
-    public override object CreateParameter(SqlParameter sqlParameter)
+    public override DbParameter CreateParameter(string parameterName, object? parameterValue = null)
     {
-        throw new NotImplementedException();
+        return new SqlParameter(parameterName, parameterValue);
     }
 
     /// <inheritdoc/>
-    public override object Dbtype()
+    public override DbCommand CreateCommand()
     {
-        throw new NotImplementedException();
+        return new SqlCommand();
+    }
+
+    /// <inheritdoc/>
+    public override DbType Dbtype()
+    {
+        throw new NotSupportedException();
     }
 
     /// <inheritdoc/>
     public override string RestructureForBatch(string sql, bool isDelete = false)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 
     /// <inheritdoc/>
-    public override void SetDbTypeParam(object npgsqlParameter, object dbType)
+    public override void SetDbTypeParam(DbParameter parameter, DbType dbType)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteAdapter.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteAdapter.cs
@@ -36,7 +36,7 @@ public class SqliteAdapter : ISqlOperationsAdapter
     /// <inheritdoc/>
     public static async Task InsertAsync<T>(DbContext context, Type type, IEnumerable<T> entities, TableInfo tableInfo, Action<decimal>? progress, bool isAsync, CancellationToken cancellationToken)
     {
-        SqliteConnection? connection = (SqliteConnection?)SqlAdaptersMapping.DbServer!.DbConnection;
+        SqliteConnection? connection = (SqliteConnection?)SqlAdaptersMapping.DbServer.DbConnection;
         if (connection == null)
         {
             connection = isAsync ? await OpenAndGetSqliteConnectionAsync(context, cancellationToken).ConfigureAwait(false)
@@ -52,7 +52,7 @@ public class SqliteAdapter : ISqlOperationsAdapter
                 doExplicitCommit = true;
             }
 
-            SqliteTransaction? transaction = (SqliteTransaction?)SqlAdaptersMapping.DbServer!.DbTransaction;
+            SqliteTransaction? transaction = (SqliteTransaction?)SqlAdaptersMapping.DbServer.DbTransaction;
             if (transaction == null)
             {
                 var dbTransaction = doExplicitCommit ? connection.BeginTransaction()
@@ -235,8 +235,8 @@ public class SqliteAdapter : ISqlOperationsAdapter
 
             tableInfo.BulkConfig.OperationType = OperationType.Insert;
             tableInfo.InsertToTempTable = true;
-            SqlAdaptersMapping.DbServer!.DbConnection = connection;
-            SqlAdaptersMapping.DbServer!.DbTransaction = transaction;
+            SqlAdaptersMapping.DbServer.DbConnection = connection;
+            SqlAdaptersMapping.DbServer.DbTransaction = transaction;
             // INSERT
             if (isAsync)
             {

--- a/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteDialect.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteDialect.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
-using System.Data;
+using System.Data.Common;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -12,12 +12,12 @@ namespace EFCore.BulkExtensions.SqlAdapters.Sqlite;
 public class SqliteDialect : IQueryBuilderSpecialization
 {
     /// <inheritdoc/>
-    public List<object> ReloadSqlParameters(DbContext context, List<object> sqlParameters)
+    public List<DbParameter> ReloadSqlParameters(DbContext context, List<DbParameter> sqlParameters)
     {
-        var sqlParametersReloaded = new List<object>();
+        var sqlParametersReloaded = new List<DbParameter>();
         foreach (var parameter in sqlParameters)
         {
-            var sqlParameter = (IDbDataParameter) parameter;
+            var sqlParameter = parameter;
             sqlParametersReloaded.Add(new SqliteParameter(sqlParameter.ParameterName, sqlParameter.Value));
         }
 

--- a/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteQueryBuilder.cs
+++ b/EFCore.BulkExtensions/SqlAdapters/Sqlite/SqliteQueryBuilder.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Data.SqlClient;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
 using System.Linq;
+using Microsoft.Data.Sqlite;
 
 namespace EFCore.BulkExtensions.SqlAdapters.Sqlite;
 
@@ -134,26 +136,32 @@ public class SqliteQueryBuilder : SqlQueryBuilder
     }
 
     /// <inheritdoc/>
-    public override object CreateParameter(SqlParameter sqlParameter)
+    public override DbParameter CreateParameter(string parameterName, object? parameterValue = null)
     {
-        throw new NotImplementedException();
+        return new SqliteParameter();
     }
 
     /// <inheritdoc/>
-    public override object Dbtype()
+    public override DbCommand CreateCommand()
     {
-        throw new NotImplementedException();
+        return new SqliteCommand();
+    }
+
+    /// <inheritdoc/>
+    public override DbType Dbtype()
+    {
+        throw new NotSupportedException();
     }
 
     /// <inheritdoc/>
     public override string RestructureForBatch(string sql, bool isDelete = false)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 
     /// <inheritdoc/>
-    public override void SetDbTypeParam(object npgsqlParameter, object dbType)
+    public override void SetDbTypeParam(DbParameter parameter, DbType dbType)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException();
     }
 }

--- a/EFCore.BulkExtensions/TableInfo.cs
+++ b/EFCore.BulkExtensions/TableInfo.cs
@@ -314,7 +314,7 @@ public class TableInfo
 
         if (isSqlServer || isNpgsql || isMySql)
         {
-            var strategyName = SqlAdaptersMapping.DbServer!.ValueGenerationStrategy;
+            var strategyName = SqlAdaptersMapping.DbServer.ValueGenerationStrategy;
             if (!strategyName.Contains(":Value"))
             {
                 strategyName = strategyName.Replace("Value", ":Value"); //example 'SqlServer:ValueGenerationStrategy'
@@ -326,7 +326,7 @@ public class TableInfo
                 bool hasIdentity = false;
                 if (annotation != null)
                 {
-                    hasIdentity = SqlAdaptersMapping.DbServer!.PropertyHasIdentity(annotation);
+                    hasIdentity = SqlAdaptersMapping.DbServer.PropertyHasIdentity(annotation);
                 }
                 if (hasIdentity)
                 {
@@ -813,12 +813,11 @@ public class TableInfo
         {
             sqlQueryCounts.Add(sqlQueryCountBase + $"'{actionCode}'");
 
-            var resultParameter = (IDbDataParameter?)Activator.CreateInstance(typeof(Microsoft.Data.SqlClient.SqlParameter));
+            var resultParameter = SqlAdaptersMapping.DbServer.QueryBuilder.CreateParameter("@result" + actionCode, null);
             if (resultParameter is null)
             {
                 throw new ArgumentException("Unable to create an instance of IDbDataParameter");
             }
-            resultParameter.ParameterName = "@result" + actionCode;
             resultParameter.DbType = DbType.Int32;
             resultParameter.Direction = ParameterDirection.Output;
 
@@ -1213,7 +1212,7 @@ public class TableInfo
         if (BulkConfig.SetOutputIdentity && (hasIdentity || tableInfo.TimeStampColumnName == null))
         {
             var databaseType = SqlAdaptersMapping.GetDatabaseType();
-            string sqlQuery = SqlAdaptersMapping.DbServer!.QueryBuilder.SelectFromOutputTable(this);
+            string sqlQuery = SqlAdaptersMapping.DbServer.QueryBuilder.SelectFromOutputTable(this);
             //var entitiesWithOutputIdentity = await QueryOutputTableAsync<T>(context, sqlQuery).ToListAsync(cancellationToken).ConfigureAwait(false); // TempFIX
             var entitiesWithOutputIdentity = QueryOutputTable(context, type, sqlQuery).Cast<object>().ToList();
             //var entitiesWithOutputIdentity = (typeof(T) == type) ? QueryOutputTable<object>(context, sqlQuery).ToList() : QueryOutputTable(context, type, sqlQuery).Cast<object>().ToList();


### PR DESCRIPTION
Hi,

This is a correctly done version of PR #1445 and follow up of #1447.

All references to SqlClient api (SqlCommand, SqlParameter, SqlBulkCopyOptions, SqlBulkCopyColumnOrderHint) have been removed from the shared code.

All usage of SqlCommand and SqlParameter have been replaced with DbParameter and the specific type instanciated in the provider specific QueryBuilder.

The SqlBulkCopyOptions and SqlBulkCopyColumnOrderHint used in BulkConfig was copied.
A better solution would be to use pre-compilation constants for each provider but the modification of the code would then be much more important, so I opted for this approach.

Finally I removed HierarchyId type usage in MySQL provider as it is a specific type of SqlServer, so the code was never reached.

Fix #1418.