### PR TITLE
Declare StrongNamer as private dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="StrongNamer" Version="0.2.5" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="" />
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="EFCoreBulk.png" Pack="true" PackagePath="" />

--- a/EFCore.BulkExtensions.Core/EFCore.BulkExtensions.Core.csproj
+++ b/EFCore.BulkExtensions.Core/EFCore.BulkExtensions.Core.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
     <PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />
-    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="NetTopologySuite" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
+++ b/EFCore.BulkExtensions.Tests/EFCore.BulkExtensions.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="RT.Comb" Version="4.0.1" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
     <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" Private="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EFCore.BulkExtensions\EFCore.BulkExtensions.csproj" />


### PR DESCRIPTION
StrongNamer is only used during build and not needed at runtime so declare it as private to not be listed in nuget dependencies.