### PR TITLE
Add inherited & owned logic

### DIFF
--- a/EFCore.BulkExtensions.Core/TableInfo.cs
+++ b/EFCore.BulkExtensions.Core/TableInfo.cs
@@ -586,11 +586,7 @@ public class TableInfo
                         prefix += $"{property.Name}_";
 
                         //Type navOwnedType = type?.Assembly.GetType(property.PropertyType.FullName!) ?? throw new ArgumentException("Unable to determine Type"); // was not used
-                        var ownedEntityType = context.Model.FindEntityType(property.PropertyType);
-                        if (ownedEntityType == null) // when entity has more then one ownedType (e.g. Address HomeAddress, Address WorkAddress) or one ownedType is in multiple Entities like Audit is usually.
-                        {
-                            ownedEntityType = context.Model.GetEntityTypes().SingleOrDefault(x => x.ClrType == property.PropertyType && x.Name.StartsWith(entityType.Name + "." + property.Name + "#"));
-                        }
+                        var ownedEntityType = context.Model.FindEntityTypes(property.PropertyType).SingleOrDefault(x => x.IsInOwnershipPath(entityType));
                         var ownedEntityProperties = ownedEntityType?.GetProperties().ToList() ?? [];
                         var ownedEntityPropertyNameColumnNameDict = new Dictionary<string, string>();
 

--- a/EFCore.BulkExtensions.SqlServer/SqlAdapters/SqlServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions.SqlServer/SqlAdapters/SqlServer/SqlServerAdapter.cs
@@ -575,8 +575,7 @@ public class SqlServerAdapter : ISqlOperationsAdapter
 
                 void AddOwnedType(PropertyInfo property, string prefix = "")
                 {
-                    var ownedEntityType = context.Model.FindEntityType(property.PropertyType);
-                    ownedEntityType ??= context.Model.GetEntityTypes().SingleOrDefault(x => x.ClrType == property.PropertyType && x.Name.StartsWith(entityType.Name + "." + property.Name + "#"));
+                    var ownedEntityType = context.Model.FindEntityTypes(property.PropertyType).SingleOrDefault(x => x.IsInOwnershipPath(entityType));
 
                     prefix += $"{property.Name}_";
 

--- a/EFCore.BulkExtensions.Tests/Owned/InheritedOwnedTests.cs
+++ b/EFCore.BulkExtensions.Tests/Owned/InheritedOwnedTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace EFCore.BulkExtensions.Tests.Owned;
+
+public class InheritedOwnedTests
+{
+    [Fact]
+    public async Task InheritedOwnedTest()
+    {
+        using var context = new InheritedDbContext(ContextUtil.GetOptions<InheritedDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_NestedOwned"));
+
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+
+        await context.BulkInsertOrUpdateAsync([
+            new CheckingAccount
+            {
+                AccountId = Guid.NewGuid(),
+                EntityInfo = new EntityInfo
+                {
+                    Key = "NZ4321"
+                },
+                Overdraft = new Overdraft
+                {
+                    Limit = 5000
+                }
+            }
+        ]);
+        await context.BulkInsertOrUpdateAsync([
+            new SavingsAccount
+            {
+                AccountId = Guid.NewGuid(),
+                EntityInfo = new EntityInfo
+                {
+                    Key = "AZ1234",
+                },
+                InterestRate = new InterestRate
+                {
+                    Rate = 6.9m
+                },
+            }
+        ]);
+        await context.BulkInsertOrUpdateAsync([
+            new Client
+            {
+                ClientId = Guid.NewGuid(),
+                Name = "Mike Mao",
+                EntityInfo = new EntityInfo
+                {
+                    Key = "MM123",
+                }
+            }
+        ]);
+
+        var checkingAccount = await context.CheckingAccounts.SingleAsync();
+        Assert.Equal("NZ4321", checkingAccount.EntityInfo.Key);
+        Assert.Equal(5000, checkingAccount.Overdraft.Limit);
+
+        var savingsAccount = await context.SavingsAccounts.SingleAsync();
+        Assert.Equal("AZ1234", savingsAccount.EntityInfo.Key);
+        Assert.Equal(6.9m, savingsAccount.InterestRate.Rate);
+        
+        var client = await context.Clients.SingleAsync();
+        Assert.Equal("MM123", client.EntityInfo.Key);
+        Assert.Equal("Mike Mao", client.Name);
+    }
+}
+
+public record Client
+{
+    [Key] public Guid ClientId { get; init; }
+    public string Name { get; init; } = default!;
+    public EntityInfo EntityInfo { get; init; } = default!;
+}
+
+public abstract record AbstractAccount
+{
+    [Key] public Guid AccountId { get; init; }
+    public EntityInfo EntityInfo { get; init; } = default!;
+}
+
+public record SavingsAccount : AbstractAccount
+{
+    public InterestRate InterestRate { get; init; } = default!;
+}
+
+public record CheckingAccount : AbstractAccount
+{
+    public Overdraft Overdraft { get; init; } = default!;
+}
+
+public record EntityInfo
+{
+    public string Key { get; init; } = default!;
+}
+
+public record InterestRate
+{
+    public decimal Rate { get; init; }
+}
+
+public record Overdraft
+{
+    public decimal Limit { get; init; }
+}
+
+public class InheritedDbContext(DbContextOptions opts) : DbContext(opts)
+{
+    public DbSet<AbstractAccount> Accounts => Set<AbstractAccount>();
+    public DbSet<SavingsAccount> SavingsAccounts => Set<SavingsAccount>();
+    public DbSet<CheckingAccount> CheckingAccounts => Set<CheckingAccount>();
+    public DbSet<Client> Clients => Set<Client>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AbstractAccount>(r => r.OwnsOne(r => r.EntityInfo));
+        modelBuilder.Entity<SavingsAccount>(r => r.OwnsOne(r => r.InterestRate));
+        modelBuilder.Entity<CheckingAccount>(r => r.OwnsOne(r => r.Overdraft));
+        modelBuilder.Entity<Client>(r => r.OwnsOne(r => r.EntityInfo));
+    }
+}


### PR DESCRIPTION
Currently if an entity is owned by multiple parent and one of them happen to be inherited, the following line will not be able to find ownedEntityType because entityType is the inherited class instead of base class
```
if (ownedEntityType == null) // when entity has more then one ownedType (e.g. Address HomeAddress, Address WorkAddress) or one ownedType is in multiple Entities like Audit is usually.
                        {
                            ownedEntityType = context.Model.GetEntityTypes().SingleOrDefault(x => x.ClrType == property.PropertyType && x.Name.StartsWith(entityType.Name + "." + property.Name + "#"));
                        }
```