### PR TITLE
Fix JsonReaderException on BulkInsertAsync when SetOutputIdentity = true, and IsJson column is null

### DIFF
--- a/EFCore.BulkExtensions.SqlServer/SqlAdapters/SqlServer/SqlServerAdapter.cs
+++ b/EFCore.BulkExtensions.SqlServer/SqlAdapters/SqlServer/SqlServerAdapter.cs
@@ -845,8 +845,7 @@ public class SqlServerAdapter : ISqlOperationsAdapter
                 {
                     var columnName = property.Name; // TODO if Diff
                     var jsonPropertyValue = tableInfo.FastPropertyDict[columnName].Get(entity!);
-                    string jsonValue = System.Text.Json.JsonSerializer.Serialize(jsonPropertyValue);
-                    columnsDict[columnName] = jsonValue;
+                    columnsDict[columnName] = (jsonPropertyValue is null) ? null : System.Text.Json.JsonSerializer.Serialize(jsonPropertyValue);
                 }
             }
 


### PR DESCRIPTION
- Make sure nulls are sent to SqlBulkCopy as null, and not as the string "null" in SqlServerAdapter.InnerGetDataTable
- Fixes #1572 