### PR TITLE
Fix for issue 1638

### DIFF
--- a/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
@@ -394,9 +394,11 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
     /// <param name="tableInfo"></param>
     public static string DropUniqueIndex(TableInfo tableInfo)
     {
+        var schemaFormated = tableInfo.Schema == null ? "" : $@"""{tableInfo.Schema}"".";
         var uniqueIndexName = GetUniqueIndexName(tableInfo);
+        var fullUniqueIndexNameFormated = $@"{schemaFormated}""{uniqueIndexName}""";
 
-        var q = $@"DROP INDEX ""{uniqueIndexName}"";";
+        var q = $@"DROP INDEX {fullUniqueIndexNameFormated};";
         return q;
     }
 
@@ -429,6 +431,7 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
         var uniqueColumnNamesDash = string.Join("_", uniqueColumnNames);
         var schemaDash = tableInfo.Schema == null ? "" : $"{tableInfo.Schema}_";
         var uniqueIndexName = $"tempUniqueIndex_{schemaDash}{tableName}_{uniqueColumnNamesDash}";
+        uniqueIndexName = uniqueIndexName.Length > 64 ? uniqueIndexName[..64] : uniqueIndexName;
 
         return uniqueIndexName;
     }

--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
@@ -119,4 +119,27 @@ public class SqlQueryBuilderPostgreSqlTests
 
         Assert.Equal(expected, batchUpdate);
     }
+
+    [Fact]
+    public void DropUniqueIndexNameTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo();
+
+        string actual = PostgreSqlQueryBuilder.DropUniqueIndex(tableInfo);
+
+        string expected = @"DROP INDEX ""dbo"".""tempUniqueIndex_dbo_Item_ItemId"";";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DropUniqueIndexNameWithLongTableNameTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo();
+        tableInfo.TableName = "Temp1234567891011121314151617181920212223";
+
+        string actual = PostgreSqlQueryBuilder.DropUniqueIndex(tableInfo);
+
+        string expected = @"DROP INDEX ""dbo"".""tempUniqueIndex_dbo_Temp1234567891011121314151617181920212223_It"";";
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
fix for #1638 

- include schema name in the DROP INDEX statement
- truncate index name if it exceeds 64 characters