### PR TITLE
Add support to set ConflictOption in MySqlBulkLoader

### DIFF
--- a/EFCore.BulkExtensions.Core/BulkConfig.cs
+++ b/EFCore.BulkExtensions.Core/BulkConfig.cs
@@ -331,6 +331,11 @@ public class BulkConfig
     public List<SqlBulkCopyColumnOrderHint>? SqlBulkCopyColumnOrderHints { get; set; }
 
     /// <summary>
+    /// Set MySqlBulkLoaderConflictOption
+    /// </summary>
+    public ConflictOption ConflictOption { get; set; } = ConflictOption.None;
+
+    /// <summary>
     ///     A filter on entities to delete when using BulkInsertOrUpdateOrDelete.
     /// </summary>
     public void SetSynchronizeFilter<T>(Expression<Func<T, bool>> filter) where T : class
@@ -492,3 +497,25 @@ public enum SortOrder
     /// </summary>
     Descending = 1
 }
+
+/// <summary>
+/// Conflict option for Bulk Insert
+/// </summary>
+public enum ConflictOption
+{
+    /// <summary>
+    /// Treat conflicts as errors
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Replace conflicting rows with new rows
+    /// </summary>
+    Replace,
+
+    /// <summary>
+    /// Ignore conflicting rows and keep old rows
+    /// </summary>
+    Ignore
+}
+

--- a/EFCore.BulkExtensions.MySql/SqlAdapters/MySql/MySqlAdapter.cs
+++ b/EFCore.BulkExtensions.MySql/SqlAdapters/MySql/MySqlAdapter.cs
@@ -409,6 +409,14 @@ public class MySqlAdapter : ISqlOperationsAdapter
 
         mySqlBulkCopy.NotifyAfter = tableInfo.BulkConfig.NotifyAfter ?? tableInfo.BulkConfig.BatchSize;
         mySqlBulkCopy.BulkCopyTimeout = tableInfo.BulkConfig.BulkCopyTimeout ?? mySqlBulkCopy.BulkCopyTimeout;
+
+        mySqlBulkCopy.ConflictOption = tableInfo.BulkConfig.ConflictOption switch
+        {
+            ConflictOption.None => MySqlBulkLoaderConflictOption.None,
+            ConflictOption.Replace => MySqlBulkLoaderConflictOption.Replace,
+            ConflictOption.Ignore => MySqlBulkLoaderConflictOption.Ignore,
+            _ => throw new InvalidEnumArgumentException(nameof(tableInfo.BulkConfig.ConflictOption))
+        };
     }
 
     #endregion

--- a/README.md
+++ b/README.md
@@ -203,26 +203,27 @@ Note: Bulk ops have optional argument *Type type* that can be set to type of Ent
 ```C#
 PROPERTY : DEFAULTvalue
 ----------------------------------------------------------------------------------------------
- 1 PreserveInsertOrder: true,                   21 PropertiesToInclude: null,
- 2 SetOutputIdentity: false,                    22 PropertiesToIncludeOnCompare: null,
- 3 SetOutputNonIdentityColumns: true,           23 PropertiesToIncludeOnUpdate: null,
- 4 LoadOnlyIncludedColumns: false,              24 PropertiesToExclude: null,
- 5 BatchSize: 2000,                             25 PropertiesToExcludeOnCompare: null,
- 6 NotifyAfter: null,                           26 PropertiesToExcludeOnUpdate: null,
- 7 BulkCopyTimeout: null,                       27 UpdateByProperties: null,
- 8 TrackingEntities: false,                     28 ReplaceReadEntities: false,
- 9 UseTempDB: false,                            29 EnableShadowProperties: false,
-10 UniqueTableNameTempDb: true,                 30 CustomSqlPostProcess: null,
-11 CustomDestinationTableName: null,            31 IncludeGraph: false,
-12 CustomSourceTableName: null,                 32 OmitClauseExistsExcept: false,
-13 CustomSourceDestinationMappingColumns: null, 33 DoNotUpdateIfTimeStampChanged: false,
-14 OnConflictUpdateWhereSql: null,              34 SRID: 4326,
-15 WithHoldlock: true,                          35 DateTime2PrecisionForceRound: false,
-16 CalculateStats: false,                       36 TemporalColumns: { "PeriodStart", "PeriodEnd" },
-17 SqlBulkCopyOptions: Default,                 37 OnSaveChangesSetFK: true,
-18 SqlBulkCopyColumnOrderHints: null,           38 IgnoreGlobalQueryFilters: false,
-19 DataReader: null,                            39 EnableStreaming: false,
-20 UseOptionLoopJoin:false,                     40 ApplySubqueryLimit: 0
+ 1 PreserveInsertOrder: true,                   22 PropertiesToInclude: null,
+ 2 SetOutputIdentity: false,                    23 PropertiesToIncludeOnCompare: null,
+ 3 SetOutputNonIdentityColumns: true,           24 PropertiesToIncludeOnUpdate: null,
+ 4 LoadOnlyIncludedColumns: false,              25 PropertiesToExclude: null,
+ 5 BatchSize: 2000,                             26 PropertiesToExcludeOnCompare: null,
+ 6 NotifyAfter: null,                           27 PropertiesToExcludeOnUpdate: null,
+ 7 BulkCopyTimeout: null,                       28 UpdateByProperties: null,
+ 8 TrackingEntities: false,                     29 ReplaceReadEntities: false,
+ 9 UseTempDB: false,                            30 EnableShadowProperties: false,
+10 UniqueTableNameTempDb: true,                 31 CustomSqlPostProcess: null,
+11 CustomDestinationTableName: null,            32 IncludeGraph: false,
+12 CustomSourceTableName: null,                 33 OmitClauseExistsExcept: false,
+13 CustomSourceDestinationMappingColumns: null, 34 DoNotUpdateIfTimeStampChanged: false,
+14 OnConflictUpdateWhereSql: null,              35 SRID: 4326,
+15 WithHoldlock: true,                          36 DateTime2PrecisionForceRound: false,
+16 CalculateStats: false,                       37 TemporalColumns: { "PeriodStart", "PeriodEnd" },
+17 SqlBulkCopyOptions: Default,                 38 OnSaveChangesSetFK: true,
+18 SqlBulkCopyColumnOrderHints: null,           39 IgnoreGlobalQueryFilters: false,
+19 DataReader: null,                            40 EnableStreaming: false,
+20 UseOptionLoopJoin:false,                     41 ApplySubqueryLimit: 0
+21 ConflictOption: None
 ----------------------------------------------------------------------------------------------
 METHOD: SetSynchronizeFilter<T>
         SetSynchronizeSoftDelete<T>


### PR DESCRIPTION
The MySqlBulkLoader class has a field ConflictOption to specify how to treat duplicates during bulk inserts. Possible values are None, which is the default and current behavior in this project, Ignore and Replace.
This PR lets the user specify the wished for behavior via a new BulkConfig field, which is used when a new MySqlBulkCopy instance gets configured. If nothing is explicitly specified, the behavior is the same as the current one.