### PR TITLE
Replace constraint name check with count verification in MysqlAdapter

### DIFF
--- a/EFCore.BulkExtensions.MySql/SqlAdapters/MySql/MySqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions.MySql/SqlAdapters/MySql/MySqlQueryBuilder.cs
@@ -245,7 +245,7 @@ public class MySqlQueryBuilder : SqlQueryBuilder
 
         var uniqueConstrainName = GetUniqueConstrainName(tableInfo);
 
-        var q = $@"SELECT DISTINCT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE " +
+        var q = $@"SELECT DISTINCT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE " +
                 $@"CONSTRAINT_TYPE = 'UNIQUE' AND CONSTRAINT_NAME = '{uniqueConstrainName}';";
         return q;
     }


### PR DESCRIPTION
- Change SELECT from CONSTRAINT_NAME to COUNT(*) in SQL query
- Fixes bug where existence check relied on non-unique constraint name retrieval
- Ensures deterministic verification of unique constraint existence
- Addresses concurrency issues in constraint creation scenarios