### PR TITLE
Apply topological sort on delete to .NET >= 8.0.

### DIFF
--- a/EFCore.BulkExtensions.Core/DbContextBulkTransactionSaveChanges.cs
+++ b/EFCore.BulkExtensions.Core/DbContextBulkTransactionSaveChanges.cs
@@ -1,4 +1,4 @@
-﻿#if NET8_0
+﻿#if NET8_0_OR_GREATER
 using Medallion.Collections; // uses StrongNamer nuget to sign ref. with Strong Name
 #endif
 using Microsoft.EntityFrameworkCore;
@@ -62,7 +62,7 @@ internal static class DbContextBulkTransactionSaveChanges
         // Topologically sort insert operations by FK
         var added = entriesGroupedByEntity.Where(x => x.State == EntityState.Added);
         var addedLookup = added.ToLookup(x => x.EntityType);
-#if NET8_0
+#if NET8_0_OR_GREATER
         var sortedAdded = added.OrderTopologicallyBy(g => getFks(g.EntityType).SelectMany(x => addedLookup[x]));
 #else
         var sortedAdded = added;
@@ -71,7 +71,7 @@ internal static class DbContextBulkTransactionSaveChanges
         // Topologically sort delete operations by reverse FK
         var deleted = entriesGroupedByEntity.Where(x => x.State == EntityState.Deleted);
         var deletedLookup = deleted.ToLookup(x => x.EntityType);
-#if NET8_0
+#if NET8_0_OR_GREATER
         var sortedDeleted = deleted.OrderTopologicallyBy(g => getFks(g.EntityType).SelectMany(x => deletedLookup[x])).Reverse();
 #else
         var sortedDeleted = deleted;
@@ -265,7 +265,7 @@ internal static class DbContextBulkTransactionSaveChanges
         { EntityState.Modified, new KeyValuePair<string, int>(nameof(DbContextBulkExtensions.BulkUpdate), 2) },
         { EntityState.Added, new KeyValuePair<string, int>(nameof(DbContextBulkExtensions.BulkInsert), 3)},
     };
-    #endregion
+#endregion
 
     private static List<BulkMethodEntries> GetBulkMethodEntries(IEnumerable<EntityEntry> entries)
     {


### PR DESCRIPTION
This change applys the topological sort on deletions to .NET 9 (and future higher versions), as well as .NET 8.