### PR TITLE
Add AutoExcludeTimestamp support to BulkConfig

### DIFF
--- a/EFCore.BulkExtensions.Core/BulkConfig.cs
+++ b/EFCore.BulkExtensions.Core/BulkConfig.cs
@@ -37,6 +37,10 @@ public class BulkConfig
     public bool SetOutputNonIdentityColumns { get; set; } = true;
 
     /// <summary>
+    /// Automatically exclude properties marked as Timestamp / RowVersion during Bulk operations.
+    /// </summary>
+    public bool AutoExcludeTimestamp { get; set; } = true;
+    /// <summary>
     ///    Used only when SetOutputIdentity is set to true, and when changed to True then columns that were no included in Upsert are not loaded.
     /// </summary>
     public bool LoadOnlyIncludedColumns { get; set; } = false;

--- a/EFCore.BulkExtensions.Core/TableInfo.cs
+++ b/EFCore.BulkExtensions.Core/TableInfo.cs
@@ -346,6 +346,23 @@ public class TableInfo
                                               )?.GetColumnName(ObjectIdentifier);
         }
 
+        if (BulkConfig.AutoExcludeTimestamp)
+        {
+            var timestampProps = allProperties
+                .Where(p => p.IsConcurrencyToken && p.ValueGenerated == ValueGenerated.OnAddOrUpdate)
+                .Select(p => p.Name)
+                .ToList();
+
+            BulkConfig.PropertiesToExclude ??= new();
+            foreach (var prop in timestampProps)
+            {
+                if (!BulkConfig.PropertiesToExclude.Contains(prop))
+                    BulkConfig.PropertiesToExclude.Add(prop);
+            }
+        }
+
+
+
         // timestamp/row version properties are only set by the Db, the property has a [Timestamp] Attribute or is configured in FluentAPI with .IsRowVersion()
         // They can be identified by the columne type "timestamp" or .IsConcurrencyToken in combination with .ValueGenerated == ValueGenerated.OnAddOrUpdate
         string timestampDbTypeName = nameof(TimestampAttribute).Replace("Attribute", "").ToLower(); // = "timestamp";


### PR DESCRIPTION
When enabled, this flag auto-detects [Timestamp] / .IsRowVersion() columns and excludes them from all relevant insert, update, and compare operations by automatically populating PropertiesToExclude.

This prevents SqlBulkCopy errors caused by rowversion columns, especially in entities using concurrency tokens.

    Fully backwards-compatible

    Opt-in via BulkConfig.AutoExcludeTimestamp = true

     Works alongside IgnoreRowVersion and other property filters

Closes issue #1753