### PR TITLE
fix:System.ArgumentOutOfRangeException

### DIFF
--- a/EFCore.BulkExtensions.Oracle/SqlAdapters/Oracle/OracleAdapter.cs
+++ b/EFCore.BulkExtensions.Oracle/SqlAdapters/Oracle/OracleAdapter.cs
@@ -645,7 +645,8 @@ public class OracleAdapter : ISqlOperationsAdapter
         if (!tableInfo.BulkConfig.EnableShadowProperties && tableInfo.ShadowProperties.Count > 0)
         {
             var stringColumns = tableInfo.ColumnNamesTypesDict.Where(a => a.Value.Contains("char")).Select(a => a.Key).ToList();
-            discriminatorColumn = tableInfo.ShadowProperties.Where(a => stringColumns.Contains(a)).ElementAt(0);
+            if (tableInfo.ShadowProperties.Any(a => stringColumns.Contains(a)))
+                discriminatorColumn = tableInfo.ShadowProperties.Where(a => stringColumns.Contains(a)).ElementAt(0);
         }
         return discriminatorColumn;
     }


### PR DESCRIPTION
System.ArgumentOutOfRangeException
  HResult=0x80131502
  Message=Specified argument was out of the range of valid values. (Parameter 'index')
  Source=System.Linq
  StackTrace:
   在 System.Linq.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument)
   在 System.Linq.Enumerable.ElementAt[TSource](IEnumerable`1 source, Int32 index)
   在 EFCore.BulkExtensions.SqlAdapters.Oracle.OracleAdapter.GetDiscriminatorColumn(TableInfo tableInfo)
   在 EFCore.BulkExtensions.SqlAdapters.Oracle.OracleAdapter.InnerGetDataTable[T](DbContext context, Type& type, IEnumerable`1 entities, TableInfo tableInfo)
   在 EFCore.BulkExtensions.SqlAdapters.Oracle.OracleAdapter.GetDataTable[T](DbContext context, Type type, IEnumerable`1 entities, OracleBulkCopy OracleBulkCopy, TableInfo tableInfo)