### PR TITLE
Honor BulkCopyTimeout in PostgreSQL adapter

### DIFF
--- a/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -47,6 +47,15 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
             using var writer = isAsync ? await connection.BeginBinaryImportAsync(sqlCopy, cancellationToken).ConfigureAwait(false)
                                              : connection.BeginBinaryImport(sqlCopy);
 
+            // BeginBinaryImport runs StartUserAction which resets the connector's read/write buffer
+            // timeouts to Settings.CommandTimeout (it passes command: null, so there is no other
+            // source). Apply BulkCopyTimeout here so it actually reaches the COPY — matches the
+            // SqlServer adapter, which assigns SqlBulkCopy.BulkCopyTimeout in the same spot.
+            if (tableInfo.BulkConfig.BulkCopyTimeout is int bulkCopyTimeout)
+            {
+                writer.Timeout = TimeSpan.FromSeconds(bulkCopyTimeout);
+            }
+
             var uniqueColumnName = tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList().FirstOrDefault();
 
             var doKeepIdentity = tableInfo.BulkConfig.SqlBulkCopyOptions == SqlBulkCopyOptions.KeepIdentity;
@@ -502,6 +511,10 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
         using (var command = connection.CreateCommand())
         {
             command.CommandText = countUniqueConstrain;
+            if (tableInfo.BulkConfig.BulkCopyTimeout is int bulkCopyTimeout)
+            {
+                command.CommandTimeout = bulkCopyTimeout;
+            }
 
             if (isAsync)
             {
@@ -562,6 +575,10 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
             var transaction = (NpgsqlTransaction?)dbTransaction;
 
             command.CommandText = sqlQuery;
+            if (tableInfo.BulkConfig.BulkCopyTimeout is int bulkCopyTimeout)
+            {
+                command.CommandTimeout = bulkCopyTimeout;
+            }
 
             object? scalar = isAsync ? await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false)
                                            : command.ExecuteScalar();


### PR DESCRIPTION
`BulkConfig.BulkCopyTimeout` was silently ignored by the PostgreSQL adapter. Large `BulkInsertAsync` calls failed with `TimeoutException: Timeout during reading attempt` inside `NpgsqlBinaryImporter.Complete`, after the connection-string default (`Command Timeout`, 30s) — not after the configured `BulkCopyTimeout`.

There are three places in the adapter that need it:

1. `InsertAsync` — the binary COPY. Setting `writer.Timeout` BEFORE `BeginBinaryImportAsync` would not have worked: `BeginBinaryImport` calls `NpgsqlConnector.StartUserAction`, which resets `ReadBuffer.Timeout = WriteBuffer.Timeout = TimeSpan.FromSeconds(command?.CommandTimeout ?? Settings.CommandTimeout)` and passes `command: null`, so it always falls through to `Settings.CommandTimeout`. Setting it AFTER the call survives until `Complete`. This mirrors the SqlServer adapter, which assigns `SqlBulkCopy.BulkCopyTimeout` in the equivalent spot.

2. `CheckHasExplicitUniqueConstrainAsync` — `connection.CreateCommand()` bypasses EF's command pipeline, so `Database.SetCommandTimeout` does not reach it either.

3. `GetStatsNumbersPGAsync` — same as above.

`ExecuteSqlRawAsync` call sites (CREATE TABLE / MERGE / DROP / etc.) are left alone: they flow through EF's command pipeline and already pick up `Database.SetCommandTimeout`, matching the SqlServer adapter's narrow scope for `BulkCopyTimeout`.

When `BulkCopyTimeout` is null, the existing default is preserved.

Fixes https://github.com/borisdj/EFCore.BulkExtensions/issues/1951