### PR TITLE
Support ConflictOption.Ignore for PostgreSQL bulk insert

### DIFF
--- a/EFCore.BulkExtensions.Core/BulkConfig.cs
+++ b/EFCore.BulkExtensions.Core/BulkConfig.cs
@@ -335,7 +335,7 @@ public class BulkConfig
     public List<SqlBulkCopyColumnOrderHint>? SqlBulkCopyColumnOrderHints { get; set; }
 
     /// <summary>
-    /// Set MySqlBulkLoaderConflictOption
+    /// Configures how conflicts are handled during bulk insert when supported by the database provider.
     /// </summary>
     public ConflictOption ConflictOption { get; set; } = ConflictOption.None;
 

--- a/EFCore.BulkExtensions.Core/BulkConfig.cs
+++ b/EFCore.BulkExtensions.Core/BulkConfig.cs
@@ -335,7 +335,7 @@ public class BulkConfig
     public List<SqlBulkCopyColumnOrderHint>? SqlBulkCopyColumnOrderHints { get; set; }
 
     /// <summary>
-    /// Configures how conflicts are handled during bulk insert when supported by the database provider.
+    ///     Configures how conflicts are handled during bulk insert when supported by the database provider.
     /// </summary>
     public ConflictOption ConflictOption { get; set; } = ConflictOption.None;
 
@@ -522,4 +522,3 @@ public enum ConflictOption
     /// </summary>
     Ignore
 }
-

--- a/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -2,6 +2,7 @@
 using Npgsql;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -20,6 +21,16 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     // Insert
     public void Insert<T>(BulkContext context, Type type, IEnumerable<T> entities, TableInfo tableInfo, Action<decimal>? progress)
     {
+        if (!tableInfo.InsertToTempTable)
+        {
+            ValidateConflictOptionForInsert(tableInfo);
+            if (tableInfo.BulkConfig.ConflictOption == ConflictOption.Ignore)
+            {
+                Merge(context, type, entities.Cast<object>(), tableInfo, OperationType.Insert, progress);
+                return;
+            }
+        }
+
         InsertAsync(context, entities, tableInfo, progress, isAsync: false, CancellationToken.None).GetAwaiter().GetResult();
     }
 
@@ -27,6 +38,16 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     public async Task InsertAsync<T>(BulkContext context, Type type, IEnumerable<T> entities, TableInfo tableInfo, Action<decimal>? progress,
         CancellationToken cancellationToken)
     {
+        if (!tableInfo.InsertToTempTable)
+        {
+            ValidateConflictOptionForInsert(tableInfo);
+            if (tableInfo.BulkConfig.ConflictOption == ConflictOption.Ignore)
+            {
+                await MergeAsync(context, type, entities.Cast<object>(), tableInfo, OperationType.Insert, progress, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+        }
+
         await InsertAsync(context, entities, tableInfo, progress, isAsync: true, cancellationToken).ConfigureAwait(false);
     }
 
@@ -251,6 +272,11 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     protected async Task MergeAsync<T>(BulkContext context, Type type, IEnumerable<T> entities, TableInfo tableInfo, OperationType operationType, Action<decimal>? progress,
         bool isAsync, CancellationToken cancellationToken) where T : class
     {
+        if (operationType == OperationType.Insert)
+        {
+            ValidateConflictOptionForInsert(tableInfo);
+        }
+
         bool tempTableCreated = false;
         bool outputTableCreated = false;
         bool uniqueIndexCreated = false;
@@ -288,33 +314,34 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
                 outputTableCreated = true;
             }
 
-            bool hasUniqueIndex = false;
-            string joinedEntityPK = string.Join("_", tableInfo.EntityPKPropertyColumnNameDict.Keys.ToList());
-            string joinedPrimaryKeys = string.Join("_", tableInfo.PrimaryKeysPropertyColumnNameDict.Keys.ToList());
-            if (joinedEntityPK == joinedPrimaryKeys)
+            bool ignoreAllConflicts = operationType == OperationType.Insert && tableInfo.BulkConfig.ConflictOption == ConflictOption.Ignore;
+            if (!ignoreAllConflicts)
             {
-                hasUniqueIndex = true; // Explicit Constrain not required for PK
-            }
-            else
-            {
-                (hasUniqueIndex, connectionOpenedInternally) = await CheckHasExplicitUniqueConstrainAsync(dbContext, tableInfo, isAsync, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (!hasUniqueIndex)
-            {
-                string createUniqueIndex = PostgreSqlQueryBuilder.CreateUniqueIndex(tableInfo);
-                string createUniqueConstrain = PostgreSqlQueryBuilder.CreateUniqueConstrain(tableInfo);
-                if (isAsync)
+                bool hasUniqueIndex = false;
+                string joinedEntityPK = string.Join("_", tableInfo.EntityPKPropertyColumnNameDict.Keys.ToList());
+                string joinedPrimaryKeys = string.Join("_", tableInfo.PrimaryKeysPropertyColumnNameDict.Keys.ToList());
+                if (joinedEntityPK == joinedPrimaryKeys)
                 {
-                    await dbContext.Database.ExecuteSqlRawAsync(createUniqueIndex, cancellationToken).ConfigureAwait(false);
-                    //await context.Database.ExecuteSqlRawAsync(createUniqueConstrain, cancellationToken).ConfigureAwait(false); // UniqueConstrain Not needed
+                    hasUniqueIndex = true; // Explicit Constrain not required for PK
                 }
                 else
                 {
-                    dbContext.Database.ExecuteSqlRaw(createUniqueIndex);
-                    //context.Database.ExecuteSqlRaw(createUniqueConstrain); // UniqueConstrain Not needed
+                    (hasUniqueIndex, connectionOpenedInternally) = await CheckHasExplicitUniqueConstrainAsync(dbContext, tableInfo, isAsync, cancellationToken).ConfigureAwait(false);
                 }
-                uniqueIndexCreated = true;
+
+                if (!hasUniqueIndex)
+                {
+                    string createUniqueIndex = PostgreSqlQueryBuilder.CreateUniqueIndex(tableInfo);
+                    if (isAsync)
+                    {
+                        await dbContext.Database.ExecuteSqlRawAsync(createUniqueIndex, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        dbContext.Database.ExecuteSqlRaw(createUniqueIndex);
+                    }
+                    uniqueIndexCreated = true;
+                }
             }
 
             if (tableInfo.BulkConfig.CustomSourceTableName == null)
@@ -374,7 +401,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
                 tableInfo.BulkConfig.StatsInfo = new StatsInfo
                 {
                     StatsNumberInserted = numberInserted,
-                    StatsNumberUpdated = entities.Count() - numberInserted,
+                    StatsNumberUpdated = ignoreAllConflicts ? 0 : entities.Count() - numberInserted,
                 };
             }
         }
@@ -609,5 +636,29 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
     {
         var (dbConnection, closeConnectionInternally) = await OpenAndGetNpgsqlConnectionAsync(context.DbContext, isAsync, cancellationToken).ConfigureAwait(false);
         return ((NpgsqlConnection)dbConnection, closeConnectionInternally);
+    }
+    
+    private static void ValidateConflictOptionForInsert(TableInfo tableInfo)
+    {
+        switch (tableInfo.BulkConfig.ConflictOption)
+        {
+            case ConflictOption.None:
+                return;
+            case ConflictOption.Ignore when tableInfo.BulkConfig.SetOutputIdentity:
+                // Targetless ON CONFLICT DO NOTHING can skip rows for any unique/exclusion constraint.
+                // PostgreSQL only returns inserted rows, so there is no reliable conflict key for mapping skipped rows back to entities.
+                throw new NotSupportedException(
+                    $"{nameof(ConflictOption.Ignore)} with {nameof(BulkConfig.SetOutputIdentity)} is not supported for PostgreSQL. Use BulkInsertOrUpdate with PropertiesToIncludeOnUpdate when output identity is required.");
+            case ConflictOption.Ignore:
+                return;
+            case ConflictOption.Replace:
+                throw new NotSupportedException(
+                    $"{nameof(ConflictOption.Replace)} is not supported for PostgreSQL. Use BulkInsertOrUpdate instead.");
+            default:
+                throw new InvalidEnumArgumentException(
+                    nameof(tableInfo.BulkConfig.ConflictOption),
+                    (int)tableInfo.BulkConfig.ConflictOption,
+                    typeof(ConflictOption));
+        }
     }
 }

--- a/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
+++ b/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlAdapter.cs
@@ -637,7 +637,7 @@ public class PostgreSqlAdapter : ISqlOperationsAdapter
         var (dbConnection, closeConnectionInternally) = await OpenAndGetNpgsqlConnectionAsync(context.DbContext, isAsync, cancellationToken).ConfigureAwait(false);
         return ((NpgsqlConnection)dbConnection, closeConnectionInternally);
     }
-    
+
     private static void ValidateConflictOptionForInsert(TableInfo tableInfo)
     {
         switch (tableInfo.BulkConfig.ConflictOption)

--- a/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
+++ b/EFCore.BulkExtensions.PostgreSql/SqlAdapters/PostgreSql/PostgreSqlQueryBuilder.cs
@@ -145,26 +145,34 @@ public class PostgreSqlQueryBuilder : SqlQueryBuilder
             }
             var commaSeparatedColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsListInsert).Replace("[", @"""").Replace("]", @"""");
 
-            var updateByColumns = SqlQueryBuilder.GetCommaSeparatedColumns(tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList()).Replace("[", @"""").Replace("]", @"""");
-
-            var columnsListEquals = GetColumnList(tableInfo, OperationType.Insert);
-            var columnsToUpdate = columnsListEquals.Where(c => tableInfo.PropertyColumnNamesUpdateDict.ContainsValue(c)).ToList();
-            var equalsColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsToUpdate, equalsTable: "EXCLUDED").Replace("[", @"""").Replace("]", @"""");
-
             int subqueryLimit = tableInfo.BulkConfig.ApplySubqueryLimit;
             var subqueryText = subqueryLimit > 0 ? $"LIMIT {subqueryLimit} " : "";
-            bool onUpdateDoNothing = columnsToUpdate.Count == 0 || string.IsNullOrWhiteSpace(equalsColumns);
 
             q = $"INSERT INTO {tableInfo.FullTableName} ({commaSeparatedColumns}) " +
-                $"(SELECT {commaSeparatedColumns} FROM {tableInfo.FullTempTableName}) " + subqueryText +
-                $"ON CONFLICT ({updateByColumns}) " +
-                (onUpdateDoNothing
-                 ? $"DO NOTHING"
-                 : $"DO UPDATE SET {equalsColumns}");
+                $"(SELECT {commaSeparatedColumns} FROM {tableInfo.FullTempTableName}) " + subqueryText;
 
-            if (tableInfo.BulkConfig.OnConflictUpdateWhereSql != null)
+            bool ignoreAllConflicts = operationType == OperationType.Insert && tableInfo.BulkConfig.ConflictOption == ConflictOption.Ignore;
+            if (ignoreAllConflicts)
             {
-                q += $" WHERE {tableInfo.BulkConfig.OnConflictUpdateWhereSql(tableInfo.FullTableName.Replace("[", @"""").Replace("]", @""""), "EXCLUDED")}";
+                q += "ON CONFLICT DO NOTHING";
+            }
+            else
+            {
+                var updateByColumns = SqlQueryBuilder.GetCommaSeparatedColumns(tableInfo.PrimaryKeysPropertyColumnNameDict.Values.ToList()).Replace("[", @"""").Replace("]", @"""");
+                var columnsListEquals = GetColumnList(tableInfo, OperationType.Insert);
+                var columnsToUpdate = columnsListEquals.Where(c => tableInfo.PropertyColumnNamesUpdateDict.ContainsValue(c)).ToList();
+                var equalsColumns = SqlQueryBuilder.GetCommaSeparatedColumns(columnsToUpdate, equalsTable: "EXCLUDED").Replace("[", @"""").Replace("]", @"""");
+                bool onUpdateDoNothing = columnsToUpdate.Count == 0 || string.IsNullOrWhiteSpace(equalsColumns);
+
+                q += $"ON CONFLICT ({updateByColumns}) " +
+                     (onUpdateDoNothing
+                      ? "DO NOTHING"
+                      : $"DO UPDATE SET {equalsColumns}");
+
+                if (!onUpdateDoNothing && tableInfo.BulkConfig.OnConflictUpdateWhereSql != null)
+                {
+                    q += $" WHERE {tableInfo.BulkConfig.OnConflictUpdateWhereSql(tableInfo.FullTableName.Replace("[", @"""").Replace("]", @""""), "EXCLUDED")}";
+                }
             }
             appendReturning = true;
         }

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -66,19 +66,21 @@ public class EFCoreBulkTest
     public void InsertWithConflictOptionIgnorePostgreSql(SqlType sqlType)
     {
         using var context = new TestContext(sqlType);
-        context.Database.ExecuteSqlRaw($@"DELETE FROM ""{nameof(Customer)}""");
+        var existingName = $"Existing-{Guid.NewGuid()}";
+        var newName = $"New-{Guid.NewGuid()}";
+        var entities = new List<Customer>
+        {
+            new Customer { Name = existingName },
+            new Customer { Name = newName }
+        };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Ignore };
 
-        context.BulkInsert([new Customer { Name = "Existing" }]);
-        context.BulkInsert(
-            [
-                new Customer { Name = "Existing" },
-                new Customer { Name = "New" }
-            ],
-            new BulkConfig { ConflictOption = ConflictOption.Ignore });
+        context.BulkInsert(new List<Customer> { new Customer { Name = existingName } });
+        context.BulkInsert(entities, bulkConfig);
 
-        Assert.Equal(2, context.Customers.Count());
-        Assert.Single(context.Customers.Where(customer => customer.Name == "Existing"));
-        Assert.Single(context.Customers.Where(customer => customer.Name == "New"));
+        Assert.Equal(2, context.Customers.Count(customer => customer.Name == existingName || customer.Name == newName));
+        Assert.Single(context.Customers.Where(customer => customer.Name == existingName));
+        Assert.Single(context.Customers.Where(customer => customer.Name == newName));
     }
 
     [Theory]
@@ -86,10 +88,10 @@ public class EFCoreBulkTest
     public void InsertWithConflictOptionIgnoreAndSetOutputIdentityThrowsPostgreSql(SqlType sqlType)
     {
         using var context = new TestContext(sqlType);
+        var entities = new List<Customer> { new Customer { Name = "IgnoreWithIdentity" } };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true };
 
-        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(
-            [new Customer { Name = "IgnoreWithIdentity" }],
-            new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true }));
+        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(entities, bulkConfig));
 
         Assert.Contains($"{nameof(ConflictOption.Ignore)} with {nameof(BulkConfig.SetOutputIdentity)} is not supported for PostgreSQL", exception.Message);
     }
@@ -99,10 +101,10 @@ public class EFCoreBulkTest
     public void InsertWithConflictOptionReplaceThrowsPostgreSql(SqlType sqlType)
     {
         using var context = new TestContext(sqlType);
+        var entities = new List<Customer> { new Customer { Name = "Replace" } };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Replace };
 
-        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(
-            [new Customer { Name = "Replace" }],
-            new BulkConfig { ConflictOption = ConflictOption.Replace }));
+        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(entities, bulkConfig));
 
         Assert.Contains($"{nameof(ConflictOption.Replace)} is not supported for PostgreSQL", exception.Message);
     }

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTest.cs
@@ -63,6 +63,52 @@ public class EFCoreBulkTest
 
     [Theory]
     [InlineData(SqlType.PostgreSql)]
+    public void InsertWithConflictOptionIgnorePostgreSql(SqlType sqlType)
+    {
+        using var context = new TestContext(sqlType);
+        context.Database.ExecuteSqlRaw($@"DELETE FROM ""{nameof(Customer)}""");
+
+        context.BulkInsert([new Customer { Name = "Existing" }]);
+        context.BulkInsert(
+            [
+                new Customer { Name = "Existing" },
+                new Customer { Name = "New" }
+            ],
+            new BulkConfig { ConflictOption = ConflictOption.Ignore });
+
+        Assert.Equal(2, context.Customers.Count());
+        Assert.Single(context.Customers.Where(customer => customer.Name == "Existing"));
+        Assert.Single(context.Customers.Where(customer => customer.Name == "New"));
+    }
+
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
+    public void InsertWithConflictOptionIgnoreAndSetOutputIdentityThrowsPostgreSql(SqlType sqlType)
+    {
+        using var context = new TestContext(sqlType);
+
+        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(
+            [new Customer { Name = "IgnoreWithIdentity" }],
+            new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true }));
+
+        Assert.Contains($"{nameof(ConflictOption.Ignore)} with {nameof(BulkConfig.SetOutputIdentity)} is not supported for PostgreSQL", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
+    public void InsertWithConflictOptionReplaceThrowsPostgreSql(SqlType sqlType)
+    {
+        using var context = new TestContext(sqlType);
+
+        var exception = Assert.Throws<NotSupportedException>(() => context.BulkInsert(
+            [new Customer { Name = "Replace" }],
+            new BulkConfig { ConflictOption = ConflictOption.Replace }));
+
+        Assert.Contains($"{nameof(ConflictOption.Replace)} is not supported for PostgreSQL", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
     public void InsertTestPostgreSql(SqlType sqlType)
     {
         using var context = new TestContext(sqlType);

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -15,6 +15,52 @@ public class EFCoreBulkTestAsync
 {
     protected static int EntitiesNumber => 10000;
 
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
+    public async Task InsertWithConflictOptionIgnorePostgreSqlAsync(SqlType sqlType)
+    {
+        await using var context = new TestContext(sqlType);
+        await context.Database.ExecuteSqlRawAsync($@"DELETE FROM ""{nameof(Customer)}""");
+
+        await context.BulkInsertAsync([new Customer { Name = "ExistingAsync" }]);
+        await context.BulkInsertAsync(
+            [
+                new Customer { Name = "ExistingAsync" },
+                new Customer { Name = "NewAsync" }
+            ],
+            new BulkConfig { ConflictOption = ConflictOption.Ignore });
+
+        Assert.Equal(2, await context.Customers.CountAsync());
+        Assert.Single(await context.Customers.Where(customer => customer.Name == "ExistingAsync").ToListAsync());
+        Assert.Single(await context.Customers.Where(customer => customer.Name == "NewAsync").ToListAsync());
+    }
+
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
+    public async Task InsertWithConflictOptionIgnoreAndSetOutputIdentityThrowsPostgreSqlAsync(SqlType sqlType)
+    {
+        await using var context = new TestContext(sqlType);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(
+            [new Customer { Name = "IgnoreWithIdentityAsync" }],
+            new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true }));
+
+        Assert.Contains($"{nameof(ConflictOption.Ignore)} with {nameof(BulkConfig.SetOutputIdentity)} is not supported for PostgreSQL", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(SqlType.PostgreSql)]
+    public async Task InsertWithConflictOptionReplaceThrowsPostgreSqlAsync(SqlType sqlType)
+    {
+        await using var context = new TestContext(sqlType);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(
+            [new Customer { Name = "ReplaceAsync" }],
+            new BulkConfig { ConflictOption = ConflictOption.Replace }));
+
+        Assert.Contains($"{nameof(ConflictOption.Replace)} is not supported for PostgreSQL", exception.Message);
+    }
+
     // NOT USED - when running multiple async tests throws: The compiled query ctx => ctx.Items was executed with a different model than it was compiled against
     //private static readonly Func<TestContext, int> ItemsCountQuery = EF.CompileQuery<TestContext, int>(ctx => ctx.Items.Count());
     //private static readonly Func<TestContext, Item?> LastItemQuery = EF.CompileQuery<TestContext, Item?>(ctx => ctx.Items.LastOrDefault());

--- a/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
+++ b/EFCore.BulkExtensions.Tests/EFCoreBulkTestAsync.cs
@@ -20,19 +20,21 @@ public class EFCoreBulkTestAsync
     public async Task InsertWithConflictOptionIgnorePostgreSqlAsync(SqlType sqlType)
     {
         await using var context = new TestContext(sqlType);
-        await context.Database.ExecuteSqlRawAsync($@"DELETE FROM ""{nameof(Customer)}""");
+        var existingName = $"ExistingAsync-{Guid.NewGuid()}";
+        var newName = $"NewAsync-{Guid.NewGuid()}";
+        var entities = new List<Customer>
+        {
+            new Customer { Name = existingName },
+            new Customer { Name = newName }
+        };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Ignore };
 
-        await context.BulkInsertAsync([new Customer { Name = "ExistingAsync" }]);
-        await context.BulkInsertAsync(
-            [
-                new Customer { Name = "ExistingAsync" },
-                new Customer { Name = "NewAsync" }
-            ],
-            new BulkConfig { ConflictOption = ConflictOption.Ignore });
+        await context.BulkInsertAsync(new List<Customer> { new Customer { Name = existingName } });
+        await context.BulkInsertAsync(entities, bulkConfig);
 
-        Assert.Equal(2, await context.Customers.CountAsync());
-        Assert.Single(await context.Customers.Where(customer => customer.Name == "ExistingAsync").ToListAsync());
-        Assert.Single(await context.Customers.Where(customer => customer.Name == "NewAsync").ToListAsync());
+        Assert.Equal(2, await context.Customers.CountAsync(customer => customer.Name == existingName || customer.Name == newName));
+        Assert.Single(await context.Customers.Where(customer => customer.Name == existingName).ToListAsync());
+        Assert.Single(await context.Customers.Where(customer => customer.Name == newName).ToListAsync());
     }
 
     [Theory]
@@ -40,10 +42,10 @@ public class EFCoreBulkTestAsync
     public async Task InsertWithConflictOptionIgnoreAndSetOutputIdentityThrowsPostgreSqlAsync(SqlType sqlType)
     {
         await using var context = new TestContext(sqlType);
+        var entities = new List<Customer> { new Customer { Name = "IgnoreWithIdentityAsync" } };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true };
 
-        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(
-            [new Customer { Name = "IgnoreWithIdentityAsync" }],
-            new BulkConfig { ConflictOption = ConflictOption.Ignore, SetOutputIdentity = true }));
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(entities, bulkConfig));
 
         Assert.Contains($"{nameof(ConflictOption.Ignore)} with {nameof(BulkConfig.SetOutputIdentity)} is not supported for PostgreSQL", exception.Message);
     }
@@ -53,10 +55,10 @@ public class EFCoreBulkTestAsync
     public async Task InsertWithConflictOptionReplaceThrowsPostgreSqlAsync(SqlType sqlType)
     {
         await using var context = new TestContext(sqlType);
+        var entities = new List<Customer> { new Customer { Name = "ReplaceAsync" } };
+        var bulkConfig = new BulkConfig { ConflictOption = ConflictOption.Replace };
 
-        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(
-            [new Customer { Name = "ReplaceAsync" }],
-            new BulkConfig { ConflictOption = ConflictOption.Replace }));
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => context.BulkInsertAsync(entities, bulkConfig));
 
         Assert.Contains($"{nameof(ConflictOption.Replace)} is not supported for PostgreSQL", exception.Message);
     }

--- a/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
+++ b/EFCore.BulkExtensions.Tests/SqlQueryBuilderPostgreSqlTests.cs
@@ -53,6 +53,20 @@ public class SqlQueryBuilderPostgreSqlTests
     }
 
     [Fact]
+    public void MergeTableInsertWithConflictOptionIgnoreTest()
+    {
+        TableInfo tableInfo = GetTestTableInfo(conflictOption: ConflictOption.Ignore);
+        tableInfo.IdentityColumnName = "ItemId";
+
+        string actual = PostgreSqlQueryBuilder.MergeTable<Item>(tableInfo, OperationType.Insert);
+
+        string expected = @"INSERT INTO ""dbo"".""Item"" (""Name"") " +
+                          @"(SELECT ""Name"" FROM ""dbo"".""ItemTemp1234"") " +
+                          @"ON CONFLICT DO NOTHING;";
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void MergeTableUpdateOnlyTest()
     {
         TableInfo tableInfo = GetTestTableInfo();
@@ -66,7 +80,7 @@ public class SqlQueryBuilderPostgreSqlTests
         Assert.Equal(expected, actual);
     }
     
-    private TableInfo GetTestTableInfo(Func<string, string, string>? onConflictUpdateWhereSql = null)
+    private TableInfo GetTestTableInfo(Func<string, string, string>? onConflictUpdateWhereSql = null, ConflictOption conflictOption = ConflictOption.None)
     {
         var tableInfo = new TableInfo()
         {
@@ -78,7 +92,8 @@ public class SqlQueryBuilderPostgreSqlTests
             PrimaryKeysPropertyColumnNameDict = new Dictionary<string, string> { { nameof(Item.ItemId), nameof(Item.ItemId) } },
             BulkConfig = new BulkConfig()
             {
-                OnConflictUpdateWhereSql = onConflictUpdateWhereSql
+                OnConflictUpdateWhereSql = onConflictUpdateWhereSql,
+                ConflictOption = conflictOption
             }
         };
         const string nameText = nameof(Item.Name);

--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ Return info will be within *BulkConfig.**TimeStampInfo*** in field `NumberOfSkip
 **OnSaveChangesSetFK** is used only for BulkSaveChanges. When multiply entries have FK relationship which is Db generated, this set proper value after reading parent PK from Db. IF PK are generated in memory like are some Guid then this can be set to false for better efficiency.  
 **ReplaceReadEntities** when set to True result of BulkRead operation will be provided using replace instead of update. Entities list parameter of BulkRead method will be repopulated with obtained data. Enables functionality of Contains/IN which will return all entities matching the criteria (does not have to be by unique columns).  
 **UseOptionLoopJoin** when set it appends 'OPTION (LOOP JOIN)' for SqlServer, to reduce potential deadlocks on tables that have FKs. Use this [sql hint](https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver16) as a last resort for experienced devs and db admins.  
-**ConflictOption**: -*None*(as errors), -*Replace*(conflicting with new rows), -*Ignore*(keep old rows). Supported only for MySQL and PostgreSQL.  
-For PostgreSQL *Replace* and combining *Ignore* with *SetOutputIdentity* are not supported.  
+**ConflictOption**: -*None*(as errors), -*Replace*(conflicting with new rows), -*Ignore*(keep old rows). Supported by MySQL; PostgreSQL supports *Ignore* only.  
+For PostgreSQL combining *Ignore* with *SetOutputIdentity* is not supported.  
 **ApplySubqueryLimit** Default is zero '0'. When set to larger value it appends: LIMIT 'N', to generated query. Used only with PostgreSql.
 
 **DataReader** can be used when DataReader is also configured and when set it is propagated to SqlBulkCopy util object.  

--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ Return info will be within *BulkConfig.**TimeStampInfo*** in field `NumberOfSkip
 **OnSaveChangesSetFK** is used only for BulkSaveChanges. When multiply entries have FK relationship which is Db generated, this set proper value after reading parent PK from Db. IF PK are generated in memory like are some Guid then this can be set to false for better efficiency.  
 **ReplaceReadEntities** when set to True result of BulkRead operation will be provided using replace instead of update. Entities list parameter of BulkRead method will be repopulated with obtained data. Enables functionality of Contains/IN which will return all entities matching the criteria (does not have to be by unique columns).  
 **UseOptionLoopJoin** when set it appends 'OPTION (LOOP JOIN)' for SqlServer, to reduce potential deadlocks on tables that have FKs. Use this [sql hint](https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver16) as a last resort for experienced devs and db admins.  
-**ConflictOption**: -*None*(as errors), -*Replace*(conflicting with new rows), -*Ignore*(keep old rows)  
+**ConflictOption**: -*None*(as errors), -*Replace*(conflicting with new rows), -*Ignore*(keep old rows). Supported only for MySQL and PostgreSQL.  
+For PostgreSQL *Replace* and combining *Ignore* with *SetOutputIdentity* are not supported.  
 **ApplySubqueryLimit** Default is zero '0'. When set to larger value it appends: LIMIT 'N', to generated query. Used only with PostgreSql.
 
 **DataReader** can be used when DataReader is also configured and when set it is propagated to SqlBulkCopy util object.  


### PR DESCRIPTION
Closes #1701

## Summary
- Adds PostgreSQL support for `BulkConfig.ConflictOption = ConflictOption.Ignore` during bulk insert.
- For PostgreSQL, `Ignore` is implemented with targetless `ON CONFLICT DO NOTHING`, so all unique/exclusion conflicts are skipped instead of failing the operation.
- Keeps `ConflictOption.Replace` unsupported for PostgreSQL and throws `NotSupportedException`.
- Rejects `ConflictOption.Ignore` together with `SetOutputIdentity`, because targetless conflict handling does not provide a reliable key for mapping skipped rows back to input entities.
- Updates README with PostgreSQL-specific notes for `ConflictOption`.