### PR TITLE
Fix shadow property metadata access for filtered properties

### DIFF
--- a/EFCore.BulkExtensions.Core/DbContextBulkTransactionSaveChanges.cs
+++ b/EFCore.BulkExtensions.Core/DbContextBulkTransactionSaveChanges.cs
@@ -117,10 +117,7 @@ internal static class DbContextBulkTransactionSaveChanges
 
                         foreach (var property in properties)
                         {
-                            if (property.PropertyInfo != null) // skip Shadow Property
-                            {
-                                entityPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property.PropertyInfo));
-                            }
+                            entityPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property, dbContext));
                         }
                         foreach (var navigationPropertyInfo in navigationPropertiesInfo)
                         {

--- a/EFCore.BulkExtensions.Core/TableInfo.cs
+++ b/EFCore.BulkExtensions.Core/TableInfo.cs
@@ -458,10 +458,7 @@ public class TableInfo
 
         foreach (var property in allProperties)
         {
-            if (property.PropertyInfo != null) // skip Shadow Property
-            {
-                FastPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property.PropertyInfo));
-            }
+            FastPropertyDict.Add(property.Name, FastProperty.GetOrCreate(property, dbContext));
 
             if (property.IsShadowProperty() && property.IsForeignKey())
             {
@@ -1066,7 +1063,7 @@ public class TableInfo
                 {
                     long value = reset ? 0 : i;
                     object idValue;
-                    var idType = identityFastProperty.Property.PropertyType;
+                    var idType = identityFastProperty.UnderlyingType ?? throw new InvalidOperationException($"Unable to determine the underlying type for '{identityPropertyName}'.");
                     if (idType == typeof(ushort))
                         idValue = (ushort)value;
                     if (idType == typeof(short))
@@ -1153,11 +1150,11 @@ public class TableInfo
         {
             var fastProperty = FastPropertyDict[identifierPropertyName];
 
-            if (fastProperty.Property.PropertyType == typeof(string) ||
-                fastProperty.Property.PropertyType == typeof(Guid))
+            var propertyType = fastProperty.UnderlyingType;
+            if (propertyType == typeof(string) || propertyType == typeof(Guid))
             {
-                entities = entities.OrderBy(p => fastProperty.Property!.GetValue(p, null)).ToList();
-                entitiesWithOutputIdentity = entitiesWithOutputIdentity.OrderBy(p => fastProperty.Property!.GetValue(p, null)).ToList();
+                entities = entities.OrderBy(p => fastProperty.Get(p!)).ToList();
+                entitiesWithOutputIdentity = entitiesWithOutputIdentity.OrderBy(p => fastProperty.Get(p)).ToList();
             }
         }
 

--- a/EFCore.BulkExtensions.Core/Util/FastProperty.cs
+++ b/EFCore.BulkExtensions.Core/Util/FastProperty.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -11,7 +13,7 @@ namespace EFCore.BulkExtensions;
 public class FastProperty
 {
     private static readonly ConcurrentDictionary<PropertyInfo, FastProperty> FastPropertyCache = new();
-    
+
     /// <summary>
     /// Get or create a <see cref="FastProperty"/> instance for getting/setting the given property.
     /// </summary>
@@ -21,11 +23,29 @@ public class FastProperty
     /// </returns>
     public static FastProperty GetOrCreate(PropertyInfo property)
     {
-        return FastPropertyCache.GetOrAdd(property, p => new FastProperty(p));
+        return FastPropertyCache.GetOrAdd(property, static p => new FastProperty(p));
     }
-    
-    private Func<object, object>? _getDelegate;
-    private Action<object, object>? _setDelegate;
+
+    /// <summary>
+    /// Get or create a <see cref="FastProperty"/> instance for the given EF Core property metadata.
+    /// </summary>
+    public static FastProperty GetOrCreate(IProperty property, DbContext? dbContext = null)
+    {
+        if (property.PropertyInfo is not null)
+        {
+            return GetOrCreate(property.PropertyInfo);
+        }
+
+        if (dbContext is null)
+        {
+            throw new ArgumentNullException(nameof(dbContext), "A DbContext is required when creating a fast accessor for a shadow property.");
+        }
+
+        return new FastProperty(property, dbContext);
+    }
+
+    private Func<object, object?>? _getDelegate;
+    private Action<object, object?>? _setDelegate;
 
     /// <summary>
     /// Constructor for FastPropery
@@ -38,12 +58,20 @@ public class FastProperty
         InitializeSet();
     }
 
+    private FastProperty(IProperty property, DbContext dbContext)
+    {
+        MetadataProperty = property;
+        Property = property.PropertyInfo;
+        InitializeShadowGet(dbContext);
+        InitializeShadowSet(dbContext);
+    }
+
     private void InitializeSet()
     {
         var instance = Expression.Parameter(typeof(object), "instance");
         var value = Expression.Parameter(typeof(object), "value");
 
-        if (Property.DeclaringType is null)
+        if (Property is null || Property.DeclaringType is null)
         {
             throw new ArgumentException("Unable to determine DeclaringType from Property");
         }
@@ -59,14 +87,14 @@ public class FastProperty
         var setter = Property.GetSetMethod(true) ?? Property.DeclaringType?.GetProperty(Property.Name)?.GetSetMethod(true); // when Prop from parent it requires DeclaringType
 
         if (setter != null)
-            _setDelegate = Expression.Lambda<Action<object, object>>(Expression.Call(instanceCast, setter, valueCast), new ParameterExpression[] { instance, value }).Compile();
+            _setDelegate = Expression.Lambda<Action<object, object?>>(Expression.Call(instanceCast, setter, valueCast), new ParameterExpression[] { instance, value }).Compile();
     }
 
     private void InitializeGet()
     {
         var instance = Expression.Parameter(typeof(object), "instance");
 
-        if (Property.DeclaringType is null)
+        if (Property is null || Property.DeclaringType is null)
         {
             throw new ArgumentException("Unable to determine DeclaringType from Property");
         }
@@ -78,12 +106,23 @@ public class FastProperty
         var getter = Property.GetGetMethod(true) ?? Property.DeclaringType.GetProperty(Property.Name)?.GetGetMethod(true);
 
         if (getter != null)
-            _getDelegate = Expression.Lambda<Func<object, object>>(Expression.TypeAs(Expression.Call(instanceCast, getter), typeof(object)), instance).Compile();
+            _getDelegate = Expression.Lambda<Func<object, object?>>(Expression.TypeAs(Expression.Call(instanceCast, getter), typeof(object)), instance).Compile();
+    }
+
+    private void InitializeShadowGet(DbContext dbContext)
+    {
+        _getDelegate = instance => dbContext.Entry(instance).Property(MetadataProperty!.Name).CurrentValue;
+    }
+
+    private void InitializeShadowSet(DbContext dbContext)
+    {
+        _setDelegate = (instance, value) => dbContext.Entry(instance).Property(MetadataProperty!.Name).CurrentValue = value;
     }
 
 #pragma warning disable CS1591 // No XML comment required here
-    public PropertyInfo Property { get; set; }
-
+    public PropertyInfo? Property { get; set; }
+    public IProperty? MetadataProperty { get; set; }
+    public Type? UnderlyingType => Property?.PropertyType ?? MetadataProperty?.ClrType;
 
     /// <summary>
     /// Returns the object
@@ -99,9 +138,11 @@ public class FastProperty
     /// <param name="value"></param>
     public void Set(object instance, object? value)
     {
-        if (value != default && _setDelegate is not null)
+        if (instance == default || _setDelegate is null)
         {
-            _setDelegate(instance, value);
+            return;
         }
+
+        _setDelegate(instance, value);
     }
 }

--- a/EFCore.BulkExtensions.GBase/SqlAdapters/GBase/GBaseAdapter.cs
+++ b/EFCore.BulkExtensions.GBase/SqlAdapters/GBase/GBaseAdapter.cs
@@ -1277,7 +1277,7 @@ public class GBaseAdapter : ISqlOperationsAdapter
         string identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
         FastProperty identityFastProperty = tableInfo.FastPropertyDict[identityPropertyName];
 
-        string idTypeName = identityFastProperty.Property.PropertyType.Name;
+        string idTypeName = (identityFastProperty.UnderlyingType ?? throw new InvalidOperationException($"Unable to determine the underlying type for '{tableInfo.IdentityColumnName}'.")).Name;
         object? idValue = null;
         for (int i = entities.Count() - 1; i >= 0; i--)
         {

--- a/EFCore.BulkExtensions.Sqlite/SqlAdapters/Sqlite/SqliteAdapter.cs
+++ b/EFCore.BulkExtensions.Sqlite/SqlAdapters/Sqlite/SqliteAdapter.cs
@@ -433,24 +433,24 @@ public class SqliteAdapter : ISqlOperationsAdapter
                     var ownedPropertyNameList = propertyColumn.Key.Split('.');
                     var ownedPropertyName = ownedPropertyNameList[0];
                     var subPropertyName = ownedPropertyNameList[1];
-                    var ownedFastProperty = tableInfo.FastPropertyDict[ownedPropertyName];
-                    var ownedProperty = ownedFastProperty.Property;
-
-                    var propertyType = Nullable.GetUnderlyingType(ownedProperty.GetType()) ?? ownedProperty.GetType();
+                    var subPropertyFullName = $"{ownedPropertyName}_{subPropertyName}";
+                    var subPropertyType = tableInfo.FastPropertyDict[subPropertyFullName].UnderlyingType ?? throw new InvalidOperationException($"Unable to determine the underlying type for '{propertyColumn.Key}'.");
                     if (!command.Parameters.Contains("@" + parameterName))
                     {
-                        var parameter = new SqliteParameter($"@{parameterName}", propertyType);
+                        var parameter = new SqliteParameter($"@{parameterName}", subPropertyType);
                         command.Parameters.Add(parameter);
                     }
 
-                    if (ownedProperty == null)
+                    var ownedFastProperty = tableInfo.FastPropertyDict[ownedPropertyName];
+                    var ownedProperty = ownedFastProperty.Property;
+
+                    if (ownedProperty is null)
                     {
                         value = null;
                     }
                     else
                     {
                         var ownedPropertyValue = entity == null ? null : tableInfo.FastPropertyDict[ownedPropertyName].Get(entity);
-                        var subPropertyFullName = $"{ownedPropertyName}_{subPropertyName}";
                         value = ownedPropertyValue == null ? null : tableInfo.FastPropertyDict[subPropertyFullName]?.Get(ownedPropertyValue);
                     }
                 }
@@ -524,7 +524,7 @@ public class SqliteAdapter : ISqlOperationsAdapter
         string identityPropertyName = tableInfo.PropertyColumnNamesDict.SingleOrDefault(a => a.Value == tableInfo.IdentityColumnName).Key;
         FastProperty identityFastProperty = tableInfo.FastPropertyDict[identityPropertyName];
 
-        string idTypeName = identityFastProperty.Property.PropertyType.Name;
+        string idTypeName = (identityFastProperty.UnderlyingType ?? throw new InvalidOperationException($"Unable to determine the underlying type for '{tableInfo.IdentityColumnName}'.")).Name;
         object? idValue = null;
         for (int i = entities.Count() - 1; i >= 0; i--)
         {

--- a/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
+++ b/EFCore.BulkExtensions.Tests/ShadowProperties/ShadowPropertyTests.cs
@@ -72,6 +72,154 @@ public class ShadowPropertyTests
         Assert.Equal(new DateTime(2021, 02, 14), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
     }
 
+    [Theory]
+    [InlineData(SqlType.SqlServer)]
+    [InlineData(SqlType.Sqlite)]
+    public void BulkInsert_EntityWithShadowProperties_WithoutEntry_UsesShadowPropertyValue(SqlType dbServer)
+    {
+        var options = new ContextUtil(dbServer)
+            .GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties_WithoutEntry");
+
+        using var db = new SpDbContext(options);
+        var entity = new SpModel();
+        var callbackCalled = false;
+
+        var exception = Record.Exception(() => db.BulkInsert(new[] { entity }, new BulkConfig
+        {
+            EnableShadowProperties = true,
+            ShadowPropertyValue = (instance, property) =>
+            {
+                callbackCalled = true;
+                Assert.Same(entity, instance);
+
+                if (property == SpModel.SpLong)
+                {
+                    return 42L;
+                }
+
+                if (property == SpModel.SpNullableLong)
+                {
+                    return null;
+                }
+
+                if (property == SpModel.SpDateTime)
+                {
+                    return new DateTime(2022, 01, 01);
+                }
+
+                throw new InvalidOperationException($"Unexpected shadow property '{property}'.");
+            }
+        }));
+
+        Assert.Null(exception);
+        Assert.True(callbackCalled);
+
+        var modelFromDb = db.SpModels.Single();
+        Assert.Equal(42L, db.Entry(modelFromDb).Property(SpModel.SpLong).CurrentValue);
+        Assert.Null(db.Entry(modelFromDb).Property(SpModel.SpNullableLong).CurrentValue);
+        Assert.Equal(new DateTime(2022, 01, 01), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+    }
+
+    [Theory]
+    [InlineData(SqlType.SqlServer)]
+    [InlineData(SqlType.Sqlite)]
+    public void BulkInsertOrUpdate_EntityWithShadowProperties_PropertiesToExcludeOnUpdate_UsesShadowPropertyValueOnCreate(SqlType dbServer)
+    {
+        var options = new ContextUtil(dbServer)
+            .GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties_ExcludeOnUpdate_Create");
+
+        using var db = new SpDbContext(options);
+        var entity = new SpModel();
+        var callbackCalled = false;
+
+        var exception = Record.Exception(() => db.BulkInsertOrUpdate(new[] { entity }, new BulkConfig
+        {
+            EnableShadowProperties = true,
+            PropertiesToExcludeOnUpdate = new List<string> { SpModel.SpLong },
+            ShadowPropertyValue = (instance, property) =>
+            {
+                callbackCalled = true;
+                Assert.Same(entity, instance);
+
+                if (property == SpModel.SpLong)
+                {
+                    return 42L;
+                }
+
+                if (property == SpModel.SpNullableLong)
+                {
+                    return null;
+                }
+
+                if (property == SpModel.SpDateTime)
+                {
+                    return new DateTime(2022, 01, 01);
+                }
+
+                throw new InvalidOperationException($"Unexpected shadow property '{property}'.");
+            }
+        }));
+
+        Assert.Null(exception);
+        Assert.True(callbackCalled);
+
+        var modelFromDb = db.SpModels.Single();
+        Assert.Equal(42L, db.Entry(modelFromDb).Property(SpModel.SpLong).CurrentValue);
+        Assert.Null(db.Entry(modelFromDb).Property(SpModel.SpNullableLong).CurrentValue);
+        Assert.Equal(new DateTime(2022, 01, 01), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+    }
+
+    [Theory]
+    [InlineData(SqlType.SqlServer)]
+    [InlineData(SqlType.Sqlite)]
+    public void BulkInsertOrUpdate_EntityWithShadowProperties_PropertiesToExclude_DoesNotThrow(SqlType dbServer)
+    {
+        var options = new ContextUtil(dbServer)
+            .GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties_Exclude");
+ 
+        using var db = new SpDbContext(options);
+        var data = GetTestData(db, true, 10).ToList();
+ 
+        var exception = Record.Exception(() => db.BulkInsertOrUpdate(data, new BulkConfig
+        {
+            EnableShadowProperties = true,
+            PropertiesToExclude = new List<string> { SpModel.SpLong }
+        }));
+ 
+        Assert.Null(exception);
+        var modelFromDb = db.SpModels.OrderByDescending(y => y.Id).First();
+        Assert.Equal(new DateTime(2021, 02, 14), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+    }
+
+    [Theory]
+    [InlineData(SqlType.SqlServer)]
+    [InlineData(SqlType.Sqlite)]
+    public void BulkInsertOrUpdate_EntityWithShadowProperties_PropertiesToExcludeOnUpdate_DoesNotThrow(SqlType dbServer)
+    {
+        var options = new ContextUtil(dbServer)
+            .GetOptions<SpDbContext>(databaseName: $"{nameof(EFCoreBulkTest)}_ShadowProperties_ExcludeOnUpdate");
+
+        using var db = new SpDbContext(options);
+        var data = GetTestData(db, true, 10).ToList();
+
+        db.BulkInsert(data, new BulkConfig { EnableShadowProperties = true });
+
+        var original = db.SpModels.First();
+        var entity = new SpModel { Id = original.Id };
+        db.Entry(entity).Property(SpModel.SpLong).CurrentValue = 42;
+        db.Entry(entity).Property(SpModel.SpDateTime).CurrentValue = new DateTime(2022, 01, 01);
+
+        var exception = Record.Exception(() => db.BulkInsertOrUpdate(new List<SpModel> { entity }, new BulkConfig
+        {
+            EnableShadowProperties = true,
+            PropertiesToExcludeOnUpdate = new List<string> { SpModel.SpLong }
+        }));
+
+        Assert.Null(exception);
+        var modelFromDb = db.SpModels.Single(x => x.Id == entity.Id);
+        Assert.Equal(new DateTime(2022, 01, 01), db.Entry(modelFromDb).Property(SpModel.SpDateTime).CurrentValue);
+    }
+
     private static IEnumerable<SpModel> GetTestData(DbContext db, bool useEf, int count)
     {
         var data = new List<SpModel>();


### PR DESCRIPTION
## Summary
This change fixes EF Core shadow-property handling in the fast-property layer used by bulk operations.

When a shadow property is included in `PropertiesToExclude`, `PropertiesToExcludeOnUpdate`, or a related filtered property list, the library was validating it as though every property had a CLR `PropertyInfo`. Shadow properties do not always have one, so they could fail with errors like:

`PropertyName 'IsDeleted' specified in 'PropertiesToExclude' not found in Properties.`

This is tied to the issues reported in #869 and #1127.

## Why this was happening
The root cause was in the internal fast accessor cache: it assumed regular reflection-based properties and skipped the EF Core metadata path for shadow properties. That broke both validation and type resolution for shadow-backed properties, especially when values were provided via `BulkConfig.ShadowPropertyValue` instead of setting `db.Entry(entity).Property(...).CurrentValue` first.

## What changed
- Added a metadata-aware `FastProperty` path for EF Core shadow properties.
- Kept the existing reflection path for normal CLR properties.
- Centralized type resolution via a shared `UnderlyingType` abstraction so identity and output work do not assume a default `long` when the backing property is shadow-based.
- Updated templated SQL adapter identity output logic to use the actual property type from metadata.
- Added regression tests covering:
  - `PropertiesToExclude`
  - `PropertiesToExcludeOnUpdate`
  - `BulkConfig.ShadowPropertyValue` without a prior `db.Entry(...)` setup
  - create-side validation when excluded-on-update properties are used

## Validation
- Build validation passed 
- The DB-backed shadow-property tests were added and included in the suite; 